### PR TITLE
Add initial documentation structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
-# contributor-docs
-Guides, best practices, and everything needed to contribute to MetaMask repositories effectively.
+# MetaMask Contributor Documentation (DRAFT)
+
+Everything needed to contribute to MetaMask repositories effectively.
+
+- [Getting started](./getting-started/)
+  - Start here if you are a new contributor, or if you are reading this documentation for the first time.
+- [Policies](./getting-started/)
+  - Policies that all contributors are asked to follow.
+- [Procedures](./getting-started/)
+  - Procedures for every step of the software development lifecycle. 
+- [Guides](./getting-started/)
+  - A collection of guidelines and best practices.

--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -1,0 +1,3 @@
+# Getting Started (DRAFT)
+
+Start here if you are a new contributor, or if you are reading this documentation for the first time.

--- a/guides/README.md
+++ b/guides/README.md
@@ -1,0 +1,3 @@
+# Guides (DRAFT)
+
+A collection of guidelines and best practices.

--- a/policies/README.md
+++ b/policies/README.md
@@ -1,0 +1,3 @@
+# Policies (DRAFT)
+
+Policies that all contributors are asked to follow.

--- a/procedures/README.md
+++ b/procedures/README.md
@@ -1,0 +1,3 @@
+# Procedures (DRAFT)
+
+Procedures for every step of the software development lifecycle. 


### PR DESCRIPTION
Directories have been setup for each category of contributor documentation, so that it's easier to start writing.

Each category has a single-sentence description that will be expanded later.

"(DRAFT)" has been added to each header to indicate that the document is not yet complete.