### PR TITLE
Remove line length from Markdown files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.md]
+max_line_length = unset


### PR DESCRIPTION
We do not honor the line length for Markdown files that we typically use for code files in other repos. Some editors can show a marker at said line length, but in this case it is distracting. Although it's not a part of the EditorConfig spec, the `max_line_length` option is honored by some editors such as Vim and can be used to remove the marker. This commit sets that EditorConfig setting accordingly.