### PR TITLE
chore: remove all DRAFT text from contributor docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MetaMask Contributor Documentation (DRAFT)
+# MetaMask Contributor Documentation 
 
 Everything needed to contribute to MetaMask repositories effectively.
 

--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -1,3 +1,3 @@
-# Getting Started (DRAFT)
+# Getting Started 
 
 Start here if you are a new contributor, or if you are reading this documentation for the first time.

--- a/guides/README.md
+++ b/guides/README.md
@@ -1,3 +1,3 @@
-# Guides (DRAFT)
+# Guides 
 
 A collection of guidelines and best practices.

--- a/policies/README.md
+++ b/policies/README.md
@@ -1,3 +1,3 @@
-# Policies (DRAFT)
+# Policies 
 
 Policies that all contributors are asked to follow.

--- a/procedures/README.md
+++ b/procedures/README.md
@@ -1,3 +1,3 @@
-# Procedures (DRAFT)
+# Procedures 
 
 Procedures for every step of the software development lifecycle. 


### PR DESCRIPTION
This PR removes the draft text from the contributor docs section.