### PR TITLE
Lint Markdown files in docs/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .DS_Store
 dist/
 coverage/
-docs/
 
 # Logs
 logs

--- a/docs/sdlc.md
+++ b/docs/sdlc.md
@@ -13,11 +13,12 @@ This lifecycle is intended to be used by software teams including product manage
 This lifecycle integrates security into all aspects of application software development which is comprised of six phases.
 
 1. Requirements Gathering and Planning:
-  - Identify the scope, goals, and necessary resources for development
-  - Define functional and security requirements for the feature 
-    - Considering [core engineering principles](./engineering-principles.md)
-    - Security controls such as authentication, data encryption, and secure communication protocols
-  - Inform the marketing team and customer support of the projected timelines, features, and any potential market impacts
+
+- Identify the scope, goals, and necessary resources for development
+- Define functional and security requirements for the feature
+  - Considering [core engineering principles](./engineering-principles.md)
+  - Security controls such as authentication, data encryption, and secure communication protocols
+- Inform the marketing team and customer support of the projected timelines, features, and any potential market impacts
 
 2. Design:
 
@@ -26,6 +27,7 @@ This lifecycle integrates security into all aspects of application software deve
 - Document design decisions, security controls, implementation and verification
 
 3. Development:
+
 - Adhere to [coding standards and secure coding practices](../README.md)
 - Implement features and security controls according to the design
 - Conduct code review for all changes


### PR DESCRIPTION
Since all Markdown files got moved into `docs/` they haven't been getting linted. This is because `docs/` is in the `.gitignore` file, and we configure Prettier to honor that. This removes `docs/` from that file so that Prettier will see all files there.