### PR TITLE
fix: Secure Coding Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ This is a living repository — nothing is set in stone! If you're member of Met
 - [Guide to Pull Requests](./docs/pull-requests.md)
 - [JavaScript Guidelines](./docs/javascript.md)
 - [Secure Development Lifecycle Policy](./docs/sdlc.md)
-- [Secure Coding Guidelines](./docs/docs/secure-coding-guidelines.md)
+- [Secure Coding Guidelines](./docs/secure-coding-guidelines.md)
 - [TypeScript Guidelines](./docs/typescript.md)
 - [Unit Testing Guidelines](./docs/unit-testing.md)

--- a/README.md
+++ b/README.md
@@ -10,5 +10,6 @@ This is a living repository — nothing is set in stone! If you're member of Met
 - [Guide to Pull Requests](./docs/pull-requests.md)
 - [JavaScript Guidelines](./docs/javascript.md)
 - [Secure Development Lifecycle Policy](./docs/sdlc.md)
+- [Secure Coding Guidelines](./docs/docs/secure-coding-guidelines.md)
 - [TypeScript Guidelines](./docs/typescript.md)
 - [Unit Testing Guidelines](./docs/unit-testing.md)

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -57,8 +57,6 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 
 #### Content Security
 
-- Verify the content type of external data to ensure it matches expectations
-- Enforce proper type checking, file type validation for file/media uploads and rendering third party content
 - Implement Content Security Policies (CSP) to mitigate XSS attacks when rendering external data
 
 #### Data Serialization

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -10,7 +10,7 @@ These guidelines apply to developers building client based applications at MetaM
 
 ## References
 
-The guidelines in this policy were gathered from concepts on the [OWASP Top 10 Site](https://owasp.org/www-project-top-ten/) and modified to meet the client applications being developed at MetaMask.
+The guidelines in this policy were gathered primarily from the [OWASP Top 10](https://owasp.org/www-project-top-ten/) and the [OWASP Application Security Verification Standard](https://owasp.org/www-project-application-security-verification-standard/). We have included just the guidelines most relevant to MetaMask client applications.
 
 ## Guidelines
 

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -30,7 +30,7 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 #### 1.2 Content Security
 
 1. Verify the content type of external data to ensure it matches expectations
-2. Enforce proper type checking, file type validation for file/media uploads and rendering 3rd party content
+2. Enforce proper type checking, file type validation for file/media uploads and rendering third party content
 3. Implement Content Security Policies (CSP) to mitigate XSS attacks when rendering external data
 
 #### 1.3 Data Serialization
@@ -73,7 +73,7 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 2. Errors should not leak data and be made more generic. This is especially important for code which handles data classified as **sensitive**.
 3. Production versions of applications shall have logging disabled
 
-### 4 3rd Party Integrations & Applications
+### 4 Third Party Integrations & Applications
 
 #### 4.1 Authentication and Authorization
 

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -14,123 +14,123 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 
 ## Guidelines
 
-### 1 Input from Users and Third Party Services
+### 1 – Input from Users and Third Party Services
 
-#### 1.1 Data Validation and Sanitization
+#### 1.1 – Data Validation and Sanitization
 
-1. Always validate and sanitize user inputs and reject any input that does not pass validation, such as:
+* 1.1.1: Always validate and sanitize user inputs and reject any input that does not pass validation, such as:
    1. Checking the type is what we expect: (e.g. is a javascript object being passed in when a string is expected)
    2. Checking if the value is what within a range we expect: (e.g. is a negative number being provided when a positive one is expected)
    3. Checking if the format is what we expect: (e.g. do we expect a `0x` prefixed hex string but an alphanumeric string is provided instead)
    4. Checking if a value matches an allowed set of constants (e.g. is the value one of the few possible numbers we expect)
-2. Validate and sanitize data from external sources before rendering it in the application's UI
-3. Preference should be given to libraries and frameworks that support input validation
-4. Avoid dynamic code execution with untrusted data to prevent injection attacks
+* 1.1.2: Validate and sanitize data from external sources before rendering it in the application's UI
+* 1.1.3: Preference should be given to libraries and frameworks that support input validation
+* 1.1.4: Avoid dynamic code execution with untrusted data to prevent injection attacks
 
-#### 1.2 Content Security
+#### 1.2 – Content Security
 
-1. Verify the content type of external data to ensure it matches expectations
-2. Enforce proper type checking, file type validation for file/media uploads and rendering third party content
-3. Implement Content Security Policies (CSP) to mitigate XSS attacks when rendering external data
+* 1.2.1: Verify the content type of external data to ensure it matches expectations
+* 1.2.2: Enforce proper type checking, file type validation for file/media uploads and rendering third party content
+* 1.2.3: Implement Content Security Policies (CSP) to mitigate XSS attacks when rendering external data
 
-#### 1.3 Data Serialization
+#### 1.3 – Data Serialization
 
-1. Recommend using pure data formats such as CSV, JSON for serialization to avoid deserialization attacks
+* 1.3.1: Recommend using pure data formats such as CSV, JSON for serialization to avoid deserialization attacks
 
-### 2 Data Persistence & Encryption
+### 2 – Data Persistence & Encryption
 
-#### 2.1 Data Classification
+#### 2.1 – Data Classification
 
-1. Classify the data in your application into at least two groups:
-2. **Non-sensitive** data (e.g. publicly available, transactions, app theme settings, etc…)
-3. **Sensitive** data (e.g. passwords, keys)
+* 2.1.1: Classify the data in your application into at least two groups:
+* 2.1.2: **Non-sensitive** data (e.g. publicly available, transactions, app theme settings, etc…)
+* 2.1.3: **Sensitive** data (e.g. passwords, keys)
 
-#### 2.2 Data Security
+#### 2.2 – Data Security
 
-1. Encrypt **sensitive** data prior to persisting
-2. Limit the amount of time **sensitive** data is decrypted
-3. Do not bundle API tokens in client side applications unless you intend for them to be publicly accessible
+* 2.2.1: Encrypt **sensitive** data prior to persisting
+* 2.2.2: Limit the amount of time **sensitive** data is decrypted
+* 2.2.3: Do not bundle API tokens in client side applications unless you intend for them to be publicly accessible
 
-#### 2.3 Encryption
+#### 2.3 – Encryption
 
-1. **Sensitive** data should be secured at rest and in-transit using standard encryption protocols (e.g. cryptography libraries, OS level key management systems, https, etc…)
-2. Cryptography of **sensitive** data should meet a minimum standard established by the security team during a threat assessment and annual reviews
+* 2.3.1: **Sensitive** data should be secured at rest and in-transit using standard encryption protocols (e.g. cryptography libraries, OS level key management systems, https, etc…)
+* 2.3.2: Cryptography of **sensitive** data should meet a minimum standard established by the security team during a threat assessment and annual reviews
 
-#### 2.4 Passwords
+#### 2.4 – Passwords
 
-1. Passwords used to decrypt content should adhere to security team recommendations during a threat assessment and annual reviews.
+* 2.4.1: Passwords used to decrypt content should adhere to security team recommendations during a threat assessment and annual reviews.
 
-### 3 Logging & Error Handling
+### 3 – Logging & Error Handling
 
-#### 3.1 Logging
+#### 3.1 – Logging
 
-1. Secrets and **sensitive** data should not be logged
-2. Console logging should be removed from production code using linters
+* 3.1.1: Secrets and **sensitive** data should not be logged
+* 3.1.2: Console logging should be removed from production code using linters
 
-#### 3.2 Error Handling
+#### 3.2 – Error Handling
 
-1. All errors should be handled
-2. Errors should not leak data and be made more generic. This is especially important for code which handles data classified as **sensitive**.
-3. Production versions of applications shall have logging disabled
+* 3.2.1: All errors should be handled
+* 3.2.2: Errors should not leak data and be made more generic. This is especially important for code which handles data classified as **sensitive**.
+* 3.2.3: Production versions of applications shall have logging disabled
 
-### 4 Third Party Integrations & Applications
+### 4 – Third Party Integrations & Applications
 
-#### 4.1 Authentication and Authorization
+#### 4.1 – Authentication and Authorization
 
-1. Implement access controls and authentication mechanisms for accessing external data
-2. Store and manage API keys securely when accessing external sources
-3. API keys used in client applications shall have a reduced scope adhering to Principle of Least Privilege
-4. If an API key is not intended to be publicly accessible, do not use it in a client application
+* 4.1.1: Implement access controls and authentication mechanisms for accessing external data
+* 4.1.2: Store and manage API keys securely when accessing external sources
+* 4.1.3: API keys used in client applications shall have a reduced scope adhering to Principle of Least Privilege
+* 4.1.4: If an API key is not intended to be publicly accessible, do not use it in a client application
 
-#### 4.2 Integration/Application Integrity
+#### 4.2 – Integration/Application Integrity
 
-1. Monitor integrations/applications for changes and security issues.
+* 4.2.1: Monitor integrations/applications for changes and security issues.
 
-#### 4.3 Permissions
+#### 4.3 – Permissions
 
-1. All applications/dapps/snaps shall adhere to the following to Principle of Least Privilege with a default state of allowing no permissions
-2. Users shall provide consent for required permissions of applications/dapps/snaps
+* 4.3.1: All applications/dapps/snaps shall adhere to the following to Principle of Least Privilege with a default state of allowing no permissions
+* 4.3.2: Users shall provide consent for required permissions of applications/dapps/snaps
 
-### 5 Dependency Management
+### 5 – Dependency Management
 
-#### 5.1 Dependency Integrity
+#### 5.1 – Dependency Integrity
 
-1. Use Dependabot to keep all dependencies up to date and to automate checks for updates
-2. Pin dependency versions or use a yarn.lock file
+* 5.1.1: Use Dependabot to keep all dependencies up to date and to automate checks for updates
+* 5.1.2: Pin dependency versions or use a yarn.lock file
 
-#### 5.2 Avoid Deprecated and Unmaintained Packages
+#### 5.2 – Avoid Deprecated and Unmaintained Packages
 
-1. Using Socket.dev to check the health and maintenance status of dependencies and seek alternatives when necessary
+* 5.2.1: Using Socket.dev to check the health and maintenance status of dependencies and seek alternatives when necessary
 
-#### 5.3 Review Dependency Licenses
+#### 5.3 – Review Dependency Licenses
 
-1. Ensure dependencies' licenses align with your project's requirements
+* 5.3.1: Ensure dependencies' licenses align with your project's requirements
 
-#### 5.4 Reduce Dependencies and Keep Them Minimal
+#### 5.4 – Reduce Dependencies and Keep Them Minimal
 
-1. Minimize dependencies to reduce potential vulnerabilities
+* 5.4.1: Minimize dependencies to reduce potential vulnerabilities
 
-#### 5.5 Audit and Monitor Dependencies
+#### 5.5 – Audit and Monitor Dependencies
 
-1. Projects should use the npm audit, Dependabot and Socket.dev tooling for periodic automated auditing of dependencies
+* 5.5.1: Projects should use the npm audit, Dependabot and Socket.dev tooling for periodic automated auditing of dependencies
 
-#### 5.6 LavaMoat
+#### 5.6 – LavaMoat
 
-1. LavaMoat allow-scripts should be enabled on all projects
-2. LavaMoat runtime should be enabled on all projects
+* 5.6.1: LavaMoat allow-scripts should be enabled on all projects
+* 5.6.2: LavaMoat runtime should be enabled on all projects
 
-### 6 Operations & Infrastructure
+### 6 – Operations & Infrastructure
 
-#### 6.1 Project secrets
+#### 6.1 – Project secrets
 
-1. Project secrets should be generated and shared using a password management system (1Password) and access to that system should follow the Principle of Least Authority
-2. Build systems needing access to project secrets should store secrets in specific secret storage and obscured once placed into system
+* 6.1.1: Project secrets should be generated and shared using a password management system (1Password) and access to that system should follow the Principle of Least Authority
+* 6.1.2: Build systems needing access to project secrets should store secrets in specific secret storage and obscured once placed into system
 
-#### 6.2 Application Integrity
+#### 6.2 – Application Integrity
 
-1. Application should be distributed through approved store portals (GitHub, App Store, Play Store, Firefox Store, Chrome Store)
-2. Each distribution channel shall have provide release verifiability (certificate signing approval, hash verification)
+* 6.2.1: Application should be distributed through approved store portals (GitHub, App Store, Play Store, Firefox Store, Chrome Store)
+* 6.2.2: Each distribution channel shall have provide release verifiability (certificate signing approval, hash verification)
 
-#### 6.3 Auditability
+#### 6.3 – Auditability
 
-1. All systems supporting the application shall have capability to audit modifications to the system
+* 6.3.1: All systems supporting the application shall have capability to audit modifications to the system

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -120,7 +120,7 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 #### Dependency Integrity
 
 - Use Dependabot to keep all dependencies up to date and to automate checks for updates
-- Pin dependency versions or use a yarn.lock file
+- Use a lockfile or pinned dependencies to maintain control over which version of each dependency is used
 
 #### Avoid Deprecated and Unmaintained Packages
 

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -14,86 +14,87 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 
 ## Guidelines
 
-This document identifies six categories developers should reference when working on client based applications.
+### 1. Input from Users and Third Party Services
 
-1. Input from Users and Third Party Services:
-   1. Data Validation and Sanitization:
-      1. Always validate and sanitize user inputs and reject any input that does not pass validation, such as:
-         1. Checking the type is what we expect: (e.g. is a javascript object being passed in when a string is expected)
-         2. Checking if the value is what within a range we expect: (e.g. is a negative number being provided when a positive one is expected)
-         3. Checking if the format is what we expect: (e.g. do we expect a `0x` prefixed hex string but an alphanumeric string is provided instead)
-         4. Checking if a value matches an allowed set of constants (e.g. is the value one of the few possible numbers we expect)
-      2. Validate and sanitize data from external sources before rendering it in the application's UI
-      3. Preference should be given to libraries and frameworks that support input validation
-      4. Avoid dynamic code execution with untrusted data to prevent injection attacks
-   2. Content Security:
-      1. Verify the content type of external data to ensure it matches expectations
-      2. Enforce proper type checking, file type validation for file/media uploads and rendering 3rd party content
-      3. Implement Content Security Policies (CSP) to mitigate XSS attacks when rendering external data
-   3. Data Serialization:
-      1. Recommend using pure data formats such as CSV, JSON for serialization to avoid deserialization attacks
+1.  Data Validation and Sanitization:
+    1. Always validate and sanitize user inputs and reject any input that does not pass validation, such as:
+       1. Checking the type is what we expect: (e.g. is a javascript object being passed in when a string is expected)
+       2. Checking if the value is what within a range we expect: (e.g. is a negative number being provided when a positive one is expected)
+       3. Checking if the format is what we expect: (e.g. do we expect a `0x` prefixed hex string but an alphanumeric string is provided instead)
+       4. Checking if a value matches an allowed set of constants (e.g. is the value one of the few possible numbers we expect)
+    2. Validate and sanitize data from external sources before rendering it in the application's UI
+    3. Preference should be given to libraries and frameworks that support input validation
+    4. Avoid dynamic code execution with untrusted data to prevent injection attacks
+2.  Content Security:
+    1. Verify the content type of external data to ensure it matches expectations
+    2. Enforce proper type checking, file type validation for file/media uploads and rendering 3rd party content
+    3. Implement Content Security Policies (CSP) to mitigate XSS attacks when rendering external data
+3.  Data Serialization:
+    1. Recommend using pure data formats such as CSV, JSON for serialization to avoid deserialization attacks
 
-2. Data Persistence & Encryption:
+### 2. Data Persistence & Encryption
 
-   1. Data Classification:
-      1. Classify the data in your application into at least two groups:
-      2. __Non-sensitive__ data (e.g. publicly available, transactions, app theme settings, etc…)
-      3. __Sensitive__ data (e.g. passwords, keys)
-   2. Data Security:
-      1. Encrypt __sensitive__ data prior to persisting
-      2. Limit the amount of time __sensitive__ data is decrypted
-      3. Do not bundle API tokens in client side applications unless you intend for them to be publicly accessible
-   3. Encryption:
-      1. __Sensitive__ data should be secured at rest and in-transit using standard encryption protocols (e.g. cryptography libraries, OS level key management systems, https, etc…)
-      2. Cryptography of __sensitive__ data should meet a minimum standard established by the security team during a threat assessment and annual reviews
-   4. Passwords:
-      1. Passwords used to decrypt content should adhere to security team recommendations during a threat assessment and annual reviews.
+1.  Data Classification:
+    1. Classify the data in your application into at least two groups:
+    2. **Non-sensitive** data (e.g. publicly available, transactions, app theme settings, etc…)
+    3. **Sensitive** data (e.g. passwords, keys)
+2.  Data Security:
+    1. Encrypt **sensitive** data prior to persisting
+    2. Limit the amount of time **sensitive** data is decrypted
+    3. Do not bundle API tokens in client side applications unless you intend for them to be publicly accessible
+3.  Encryption:
+    1. **Sensitive** data should be secured at rest and in-transit using standard encryption protocols (e.g. cryptography libraries, OS level key management systems, https, etc…)
+    2. Cryptography of **sensitive** data should meet a minimum standard established by the security team during a threat assessment and annual reviews
+4.  Passwords:
+    1. Passwords used to decrypt content should adhere to security team recommendations during a threat assessment and annual reviews.
 
-3. Logging & Error Handling:
+### 3. Logging & Error Handling
 
-   1. Logging:
-      1. Secrets and __sensitive__ data should not be logged
-      2. Console logging should be removed from production code using linters
-   2. Error Handling:
-      1. All errors should be handled
-      2. Errors should not leak data and be made more generic. This is especially important for code which handles data classified as __sensitive__.
-      3. Production versions of applications shall have logging disabled
+1.  Logging:
+    1. Secrets and **sensitive** data should not be logged
+    2. Console logging should be removed from production code using linters
+2.  Error Handling:
+    1. All errors should be handled
+    2. Errors should not leak data and be made more generic. This is especially important for code which handles data classified as **sensitive**.
+    3. Production versions of applications shall have logging disabled
 
-4. 3rd Party Integrations & Applications:
-   1. Authentication and Authorization:
-      1. Implement access controls and authentication mechanisms for accessing external data
-      2. Store and manage API keys securely when accessing external sources
-      3. API keys used in client applications shall have a reduced scope adhering to Principle of Least Privilege
-      4. If an API key is not intended to be publicly accessible, do not use it in a client application
-   2. Integration/Application Integrity:
-      1. Monitor integrations/applications for changes and security issues.
-   3. Permissions:
-      1. All applications/dapps/snaps shall adhere to the following to Principle of Least Privilege with a default state of allowing no permissions
-      2. Users shall provide consent for required permissions of applications/dapps/snaps
+### 4. 3rd Party Integrations & Applications
 
-5. Dependency Management:
+1.  Authentication and Authorization:
+    1. Implement access controls and authentication mechanisms for accessing external data
+    2. Store and manage API keys securely when accessing external sources
+    3. API keys used in client applications shall have a reduced scope adhering to Principle of Least Privilege
+    4. If an API key is not intended to be publicly accessible, do not use it in a client application
+2.  Integration/Application Integrity:
+    1. Monitor integrations/applications for changes and security issues.
+3.  Permissions:
+    1. All applications/dapps/snaps shall adhere to the following to Principle of Least Privilege with a default state of allowing no permissions
+    2. Users shall provide consent for required permissions of applications/dapps/snaps
 
-   1. Dependency Integrity:
-      1. Use Dependabot to keep all dependencies up to date and to automate checks for updates
-      2. Pin dependency versions or use a yarn.lock file
-   2. Avoid Deprecated and Unmaintained Packages:
-      1. Using Socket.dev to check the health and maintenance status of dependencies and seek alternatives when necessary
-   3. Review Dependency Licenses:
-      1. Ensure dependencies' licenses align with your project's requirements
-   4. Reduce Dependencies and Keep Them Minimal:
-      1. Minimize dependencies to reduce potential vulnerabilities
-   5. Audit and Monitor Dependencies:
-      1. Projects should use the npm audit, Dependabot and Socket.dev tooling for periodic automated auditing of dependencies
-   6. LavaMoat:
-      1. LavaMoat allow-scripts should be enabled on all projects
-      2. LavaMoat runtime should be enabled on all projects
+### 5. Dependency Management
 
-6. Operations & Infrastructure:
-   1. Project secrets:
-      1. Project secrets should be generated and shared using a password management system (1Password) and access to that system should follow the Principle of Least Authority
-      2. Build systems needing access to project secrets should store secrets in specific secret storage and obscured once placed into system
-   2. Application Integrity:
-      1. Application should be distributed through approved store portals (GitHub, App Store, Play Store, Firefox Store, Chrome Store)
-      2. Each distribution channel shall have provide release verifiability (certificate signing approval, hash verification)
-   3. Auditability:
-      1. All systems supporting the application shall have capability to audit modifications to the system
+1.  Dependency Integrity:
+    1. Use Dependabot to keep all dependencies up to date and to automate checks for updates
+    2. Pin dependency versions or use a yarn.lock file
+2.  Avoid Deprecated and Unmaintained Packages:
+    1. Using Socket.dev to check the health and maintenance status of dependencies and seek alternatives when necessary
+3.  Review Dependency Licenses:
+    1. Ensure dependencies' licenses align with your project's requirements
+4.  Reduce Dependencies and Keep Them Minimal:
+    1. Minimize dependencies to reduce potential vulnerabilities
+5.  Audit and Monitor Dependencies:
+    1. Projects should use the npm audit, Dependabot and Socket.dev tooling for periodic automated auditing of dependencies
+6.  LavaMoat:
+    1. LavaMoat allow-scripts should be enabled on all projects
+    2. LavaMoat runtime should be enabled on all projects
+
+### 6. Operations & Infrastructure
+
+1.  Project secrets:
+    1. Project secrets should be generated and shared using a password management system (1Password) and access to that system should follow the Principle of Least Authority
+    2. Build systems needing access to project secrets should store secrets in specific secret storage and obscured once placed into system
+2.  Application Integrity:
+    1. Application should be distributed through approved store portals (GitHub, App Store, Play Store, Firefox Store, Chrome Store)
+    2. Each distribution channel shall have provide release verifiability (certificate signing approval, hash verification)
+3.  Auditability:
+    1. All systems supporting the application shall have capability to audit modifications to the system

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -143,7 +143,12 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 
 #### LavaMoat
 
-- LavaMoat allow-scripts should be enabled on all projects
+- LavaMoat `allow-scripts` should be enabled on all projects
+  - This project relies upon install scripts being disabled in your package manager. This can be verified by adding the dependency `@lavamoat/preinstall-always-fail`, which will cause installation to fail if scripts are enabled.
+  - `allow-scripts` acts as an allowlist for install scripts. Use the `allow-scripts` binary after installing dependencies to run install scripts on the allowlist.
+    - On Yarn v3 projects, use the `yarn-plugin-allow-scripts` plugin to run allowed scripts automatically during install
+    - On other projects, use an npm script called `setup` that will call `install` and `allow-scripts` in sequence
+  - If you're unsure whether an install script is needed, leave it disabled
 - LavaMoat runtime should be enabled on all projects
 
 ### Operations & Infrastructure

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -61,7 +61,7 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 
 #### Data Serialization
 
-- Recommend using pure data formats such as CSV, JSON for serialization to avoid deserialization attacks
+- Use pure data formats (e.g. JSON, CSV) for serialization to avoid deserialization attacks
 
 ### Data Persistence & Encryption
 

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -168,5 +168,5 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 
 #### Application Integrity
 
-- Application should be distributed through approved store portals (GitHub, App Store, Play Store, Firefox Store, Chrome Store)
-- Each distribution channel shall have provide release verifiability (certificate signing approval, hash verification)
+- Application should be distributed through approved store portals (e.g. GitHub, App Store, Play Store, Firefox Store, Chrome Store)
+- Each distribution channel shall have provide release verifiability (e.g. certificate signing approval, hash verification)

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -90,7 +90,6 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 #### Logging
 
 - Secrets and **sensitive** data should not be logged
-- Console logging should be removed from production code using linters
 
 #### Error Handling
 

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -131,7 +131,15 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 
 #### Audit and Monitor Dependencies
 
-- Projects should use the npm audit, Dependabot and Socket.dev tooling for periodic automated auditing of dependencies
+- Monitor dependencies for security vulnerabilities and other problems
+  - Periodically scan for security vulnerabilities (e.g. using tools like `npm audit`)
+  - Update dependencies quickly when they have security vulnerabilities
+  - Use Socket.dev to monitor dependencies for other noteworthy changes, such as maintainer changes, or the addition of install scripts or binary files
+    - Use the following etiquette when addressing Socket.dev warnings:
+      - Investigate and address all warnings before merging a PR
+      - Avoid using the `ignore-all` bot command, instead ignoring each warning one at a time
+      - If you've investigated a warning and found that it's not indicative of a malicious dependency, ignore it with a bot comment and explain your investigation with a short comment
+      - Contact the security team if you're unsure how to investigate something, or if you'd like to disable a warning category
 
 #### LavaMoat
 

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -68,7 +68,7 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 #### Data Classification
 
 - Classify the data in your application into at least two groups:
-  - **Non-sensitive** data (e.g. publicly available, transactions, app theme settings, etc…)
+  - **Non-sensitive** data (e.g. publicly available, transactions, app theme settings, etc.)
   - **Sensitive** data (e.g. passwords, keys)
 
 #### Data Security
@@ -78,12 +78,12 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 
 #### Encryption
 
-- **Sensitive** data should be secured at rest and in-transit using standard encryption protocols (e.g. cryptography libraries, OS level key management systems, https, etc…)
+- **Sensitive** data should be secured at rest and in-transit using standard encryption protocols (e.g. cryptography libraries, OS level key management systems, https, etc.)
 - Cryptography of **sensitive** data should meet a minimum standard established by the security team during a threat assessment and annual reviews
 
 #### Passwords
 
-- Passwords used to decrypt content should adhere to security team recommendations during a threat assessment and annual reviews.
+- Passwords used to decrypt content should adhere to security team recommendations during a threat assessment and annual reviews
 
 ### Logging & Error Handling
 

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -149,7 +149,12 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
     - On Yarn v3 projects, use the `yarn-plugin-allow-scripts` plugin to run allowed scripts automatically during install
     - On other projects, use an npm script called `setup` that will call `install` and `allow-scripts` in sequence
   - If you're unsure whether an install script is needed, leave it disabled
-- LavaMoat runtime should be enabled on all projects
+- LavaMoat runtime should be used for all Node.js build systems, and LavaMoat bundling tools should be used for all JavaScript client applications
+  - The LavaMoat runtime helps protect against malicious code in dependencies by isolating dependencies and reducing their capabilities
+  - The LavaMoat bundling tools will bundle client applications with a LavaMoat runtime and policy
+  - Regularly review your LavaMoat policies for suspicious permissions
+  - When the policy is updated, carefully review the diff to ensure that the capabilities granted to each dependency seem appropriate and legitimate
+  - Consult with the LavaMoat team if you have any questions
 
 ### Operations & Infrastructure
 

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -101,7 +101,9 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 
 #### Authentication and Authorization
 
-- Store and manage API keys securely when accessing external sources
+- Store and manage API keys securely
+  - Each CI system should have a method of securely managing keys
+  - For keys used directly by developers, use 1Password
 - Do not bundle API tokens in client side applications unless you intend for them to be publicly accessible
 
 #### Integration/Application Integrity

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -101,7 +101,6 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 
 #### Authentication and Authorization
 
-- Implement access controls and authentication mechanisms for accessing external data
 - Store and manage API keys securely when accessing external sources
 - API keys used in client applications shall have a reduced scope adhering to Principle of Least Privilege
 - Do not bundle API tokens in client side applications unless you intend for them to be publicly accessible

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -95,7 +95,7 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 
 - Avoid including data directly in error messages, especially **sensitive** data
 
-  For example, the error "Invalid hex data: ____" might indadvertantly leak a private key. Instead the error could be made more generic ("Invalid hex data"), or you could describe the problem without embedding the data ("Invalid hex data; missing 0x prefix").
+  For example, the error "Invalid hex data: \_\_\_\_" might indadvertantly leak a private key. Instead the error could be made more generic ("Invalid hex data"), or you could describe the problem without embedding the data ("Invalid hex data; missing 0x prefix").
 
 ### Third Party Integrations & Applications
 
@@ -124,7 +124,6 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 #### Avoid Deprecated and Unmaintained Packages
 
 - Using Socket.dev to check the health and maintenance status of dependencies and seek alternatives when necessary
-
 
 #### Reduce Dependencies and Keep Them Minimal
 

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -16,62 +16,65 @@ The guidelines in this policy were gathered from concepts on the [OWASP Top 10 S
 
 This document identifies six categories developers should reference when working on client based applications.
 
-1. User Input:
-
-   1. Processing User Inputs:
-      1. Always validate and sanitize user inputs
-      2. Preference should be given to libraries and frameworks that support input validation
-   2. Data Serialization:
-      1. Recommend using pure data formats such as JSON for serialization to avoid deserialization attacks
+1. Input from Users and Third Party Services:
+   1. Data Validation and Sanitization:
+      1. Always validate and sanitize user inputs and reject any input that does not pass validation, such as:
+         1. Checking the type is what we expect: (e.g. is a javascript object being passed in when a string is expected)
+         2. Checking if the value is what within a range we expect: (e.g. is a negative number being provided when a positive one is expected)
+         3. Checking if the format is what we expect: (e.g. do we expect a `0x` prefixed hex string but an alphanumeric string is provided instead)
+         4. Checking if a value matches an allowed set of constants (e.g. is the value one of the few possible numbers we expect)
+      2. Validate and sanitize data from external sources before rendering it in the application's UI
+      3. Preference should be given to libraries and frameworks that support input validation
+      4. Avoid dynamic code execution with untrusted data to prevent injection attacks
+   2. Content Security:
+      1. Verify the content type of external data to ensure it matches expectations
+      2. Enforce proper type checking, file type validation for file/media uploads and rendering 3rd party content
+      3. Implement Content Security Policies (CSP) to mitigate XSS attacks when rendering external data
+   3. Data Serialization:
+      1. Recommend using pure data formats such as CSV, JSON for serialization to avoid deserialization attacks
 
 2. Data Persistence & Encryption:
 
    1. Data Classification:
       1. Classify the data in your application into at least two groups:
-      1. Non-sensitive data (e.g. publicly available, transactions, tokens, etc…)
-      1. Sensitive data (e.g. passwords, keys)
+      2. __Non-sensitive__ data (e.g. publicly available, transactions, app theme settings, etc…)
+      3. __Sensitive__ data (e.g. passwords, keys)
    2. Data Security:
-      1. Encrypt sensitive data prior to persisting
-      2. Limit the amount of time sensitive data is decrypted
+      1. Encrypt __sensitive__ data prior to persisting
+      2. Limit the amount of time __sensitive__ data is decrypted
+      3. Do not bundle API tokens in client side applications unless you intend for them to be publicly accessible
    3. Encryption:
-      1. Sensitive data should be secured at rest and in-transit using standard encryption protocols (e.g. cryptography libraries, OS level key management systems, https, etc…)
-      2. Cryptography of sensitive data should meet a minimum standard established by the security team during a threat assessment and annual reviews
+      1. __Sensitive__ data should be secured at rest and in-transit using standard encryption protocols (e.g. cryptography libraries, OS level key management systems, https, etc…)
+      2. Cryptography of __sensitive__ data should meet a minimum standard established by the security team during a threat assessment and annual reviews
    4. Passwords:
       1. Passwords used to decrypt content should adhere to security team recommendations during a threat assessment and annual reviews.
 
 3. Logging & Error Handling:
 
    1. Logging:
-      1. Secrets and sensitive data should not be logged
+      1. Secrets and __sensitive__ data should not be logged
       2. Console logging should be removed from production code using linters
    2. Error Handling:
       1. All errors should be handled
-      2. Errors should not leak data and be made more generic
+      2. Errors should not leak data and be made more generic. This is especially important for code which handles data classified as __sensitive__.
       3. Production versions of applications shall have logging disabled
 
-4. 3rd Party Data & Applications:
-
-   1. Data Validation and Sanitization:
-      1. Validate and sanitize data from external sources before rendering it in the application's UI
-      2. Avoid dynamic code execution with untrusted data to prevent injection attacks
-   2. Content Security:
-      1. Verify the content type of external data to ensure it matches expectations
-      2. Enforce proper type checking, file type validation for file/media uploads and rendering 3rd party content
-      3. Implement Content Security Policies (CSP) to mitigate XSS attacks when rendering external data
-   3. Authentication and Authorization:
+4. 3rd Party Integrations & Applications:
+   1. Authentication and Authorization:
       1. Implement access controls and authentication mechanisms for accessing external data
       2. Store and manage API keys securely when accessing external sources
       3. API keys used in client applications shall have a reduced scope adhering to Principle of Least Privilege
-   4. Data Integrity:
-      1. Monitor external data sources for changes and security issues.
-   5. Permissions:
+      4. If an API key is not intended to be publicly accessible, do not use it in a client application
+   2. Integration/Application Integrity:
+      1. Monitor integrations/applications for changes and security issues.
+   3. Permissions:
       1. All applications/dapps/snaps shall adhere to the following to Principle of Least Privilege with a default state of allowing no permissions
       2. Users shall provide consent for required permissions of applications/dapps/snaps
 
 5. Dependency Management:
 
    1. Dependency Integrity:
-      1. Keep all dependencies up to date, using tools to automate checks for updates
+      1. Use Dependabot to keep all dependencies up to date and to automate checks for updates
       2. Pin dependency versions or use a yarn.lock file
    2. Avoid Deprecated and Unmaintained Packages:
       1. Using Socket.dev to check the health and maintenance status of dependencies and seek alternatives when necessary

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -95,7 +95,6 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 
 - All errors should be handled
 - Errors should not leak data and be made more generic. This is especially important for code which handles data classified as **sensitive**
-- Production versions of applications shall have logging disabled
 
 ### Third Party Integrations & Applications
 

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -55,9 +55,9 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
   - DOM
   - `javascript:` protocol
 
-#### Content Security
+#### Content Security Policy
 
-- Implement Content Security Policies (CSP) to mitigate XSS attacks when rendering external data
+- Use a Content Security Policy (CSP) to mitigate XSS attacks when rendering external data
 
 #### Data Serialization
 

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -31,7 +31,17 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
   - Check that the format matches expectations
     - If we expect a 0x-prefixed hexadecimal string, ensure that the 0x is present
 
-- Avoid dynamic code execution with untrusted data to prevent injection attacks
+- Avoid dynamic code execution with untrusted data
+
+  Dynamic code execution of untrusted data can allow for injection attacks. Prevent this by avoiding dynamic code execution completely where possible, but especially when the code being run was derived from untrusted data.
+
+  Examples of dynamic code execution:
+
+  - `eval`
+  - `new Function`
+  - Template processors (e.g. for HTML, SQL, etc.)
+  - DOM
+  - `javascript:` protocol
 
 #### Content Security
 

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -31,7 +31,6 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
   - Check that the format matches expectations
     - If we expect a 0x-prefixed hexadecimal string, ensure that the 0x is present
 
-- Preference should be given to libraries and frameworks that support input validation
 - Avoid dynamic code execution with untrusted data to prevent injection attacks
 
 #### Content Security

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -18,12 +18,19 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 
 #### Data Validation and Sanitization
 
-- Always validate and sanitize user inputs and reject any input that does not pass validation, such as:
-  1.  Checking the type is what we expect: (e.g. is a javascript object being passed in when a string is expected)
-  2.  Checking if the value is what within a range we expect: (e.g. is a negative number being provided when a positive one is expected)
-  3.  Checking if the format is what we expect: (e.g. do we expect a `0x` prefixed hex string but an alphanumeric string is provided instead)
-  4.  Checking if a value matches an allowed set of constants (e.g. is the value one of the few possible numbers we expect)
-- Validate and sanitize data from external sources before rendering it in the application's UI
+- Validate and sanitize all user input, and all data from external sources
+
+  For example:
+
+  - Check that the type matches expectations
+    - If a value should be a string, do not allow it to be an object
+    - Validation libraries can be used for more complex types of data
+  - Check that the value is is an allowed value or within the expected range
+    - If only a fixed set of values are expected, ensure the value matches one of them
+    - If a non-negative number is expected, do not allow the value to be negative
+  - Check that the format matches expectations
+    - If we expect a 0x-prefixed hexadecimal string, ensure that the 0x is present
+
 - Preference should be given to libraries and frameworks that support input validation
 - Avoid dynamic code execution with untrusted data to prevent injection attacks
 

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -163,6 +163,8 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
   - Each CI system should have a method of securely managing secrets
   - For secrets used directly by developers, use 1Password
 - Limit access to project secrets, following the Principle of Least Authority
+- Prevent contributors from committing secrets to the repository
+  - GitHub has a "Secret scanning" setting that can help with this, and there are third-party tools like `2ms` (too many secrets) that can help as well
 
 #### Application Integrity
 

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -68,8 +68,8 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 #### Data Classification
 
 - Classify the data in your application into at least two groups:
-- **Non-sensitive** data (e.g. publicly available, transactions, app theme settings, etc…)
-- **Sensitive** data (e.g. passwords, keys)
+  - **Non-sensitive** data (e.g. publicly available, transactions, app theme settings, etc…)
+  - **Sensitive** data (e.g. passwords, keys)
 
 #### Data Security
 

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -93,7 +93,6 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 
 #### Error Handling
 
-- All errors should be handled
 - Errors should not leak data and be made more generic. This is especially important for code which handles data classified as **sensitive**
 
 ### Third Party Integrations & Applications

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -101,9 +101,6 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 
 #### Authentication and Authorization
 
-- Store and manage API keys securely
-  - Each CI system should have a method of securely managing keys
-  - For keys used directly by developers, use 1Password
 - Do not bundle API tokens in client side applications unless you intend for them to be publicly accessible
 
 #### Integration/Application Integrity
@@ -162,8 +159,10 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 
 #### Project secrets
 
-- Project secrets should be generated and shared using a password management system (1Password) and access to that system should follow the Principle of Least Authority
-- Build systems needing access to project secrets should store secrets in specific secret storage and obscured once placed into system
+- Store and manage project secrets securely
+  - Each CI system should have a method of securely managing secrets
+  - For secrets used directly by developers, use 1Password
+- Limit access to project secrets, following the Principle of Least Authority
 
 #### Application Integrity
 

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -31,6 +31,14 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
   - Check that the format matches expectations
     - If we expect a 0x-prefixed hexadecimal string, ensure that the 0x is present
 
+- Encode data before output
+
+  For example:
+
+  - HTML-encode strings before they are included in the DOM
+    - Some libraries do this automatically (e.g. React)
+  - URL-encode data before including it in a URL
+
 - Avoid dynamic code execution with untrusted data
 
   Dynamic code execution of untrusted data can allow for injection attacks. Prevent this by avoiding dynamic code execution completely where possible, but especially when the code being run was derived from untrusted data.

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -125,9 +125,6 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 
 - Using Socket.dev to check the health and maintenance status of dependencies and seek alternatives when necessary
 
-#### Review Dependency Licenses
-
-- Ensure dependencies' licenses align with your project's requirements
 
 #### Reduce Dependencies and Keep Them Minimal
 

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -74,7 +74,7 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 #### Data Security
 
 - Encrypt **sensitive** data prior to persisting
-- Limit the amount of time **sensitive** data is decrypted
+- Limit access to **sensitive** data
 
 #### Encryption
 

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -93,7 +93,9 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 
 #### Error Handling
 
-- Errors should not leak data and be made more generic. This is especially important for code which handles data classified as **sensitive**
+- Avoid including data directly in error messages, especially **sensitive** data
+
+  For example, the error "Invalid hex data: ____" might indadvertantly leak a private key. Instead the error could be made more generic ("Invalid hex data"), or you could describe the problem without embedding the data ("Invalid hex data; missing 0x prefix").
 
 ### Third Party Integrations & Applications
 

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -14,123 +14,123 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 
 ## Guidelines
 
-### 1 – Input from Users and Third Party Services
+### Input from Users and Third Party Services
 
-#### 1.1 – Data Validation and Sanitization
+#### Data Validation and Sanitization
 
-* 1.1.1: Always validate and sanitize user inputs and reject any input that does not pass validation, such as:
+* Always validate and sanitize user inputs and reject any input that does not pass validation, such as:
    1. Checking the type is what we expect: (e.g. is a javascript object being passed in when a string is expected)
    2. Checking if the value is what within a range we expect: (e.g. is a negative number being provided when a positive one is expected)
    3. Checking if the format is what we expect: (e.g. do we expect a `0x` prefixed hex string but an alphanumeric string is provided instead)
    4. Checking if a value matches an allowed set of constants (e.g. is the value one of the few possible numbers we expect)
-* 1.1.2: Validate and sanitize data from external sources before rendering it in the application's UI
-* 1.1.3: Preference should be given to libraries and frameworks that support input validation
-* 1.1.4: Avoid dynamic code execution with untrusted data to prevent injection attacks
+* Validate and sanitize data from external sources before rendering it in the application's UI
+* Preference should be given to libraries and frameworks that support input validation
+* Avoid dynamic code execution with untrusted data to prevent injection attacks
 
-#### 1.2 – Content Security
+#### Content Security
 
-* 1.2.1: Verify the content type of external data to ensure it matches expectations
-* 1.2.2: Enforce proper type checking, file type validation for file/media uploads and rendering third party content
-* 1.2.3: Implement Content Security Policies (CSP) to mitigate XSS attacks when rendering external data
+* Verify the content type of external data to ensure it matches expectations
+* Enforce proper type checking, file type validation for file/media uploads and rendering third party content
+* Implement Content Security Policies (CSP) to mitigate XSS attacks when rendering external data
 
-#### 1.3 – Data Serialization
+#### Data Serialization
 
-* 1.3.1: Recommend using pure data formats such as CSV, JSON for serialization to avoid deserialization attacks
+* Recommend using pure data formats such as CSV, JSON for serialization to avoid deserialization attacks
 
-### 2 – Data Persistence & Encryption
+### Data Persistence & Encryption
 
-#### 2.1 – Data Classification
+#### Data Classification
 
-* 2.1.1: Classify the data in your application into at least two groups:
-* 2.1.2: **Non-sensitive** data (e.g. publicly available, transactions, app theme settings, etc…)
-* 2.1.3: **Sensitive** data (e.g. passwords, keys)
+* Classify the data in your application into at least two groups:
+* **Non-sensitive** data (e.g. publicly available, transactions, app theme settings, etc…)
+* **Sensitive** data (e.g. passwords, keys)
 
-#### 2.2 – Data Security
+#### Data Security
 
-* 2.2.1: Encrypt **sensitive** data prior to persisting
-* 2.2.2: Limit the amount of time **sensitive** data is decrypted
-* 2.2.3: Do not bundle API tokens in client side applications unless you intend for them to be publicly accessible
+* Encrypt **sensitive** data prior to persisting
+* Limit the amount of time **sensitive** data is decrypted
+* Do not bundle API tokens in client side applications unless you intend for them to be publicly accessible
 
-#### 2.3 – Encryption
+#### Encryption
 
-* 2.3.1: **Sensitive** data should be secured at rest and in-transit using standard encryption protocols (e.g. cryptography libraries, OS level key management systems, https, etc…)
-* 2.3.2: Cryptography of **sensitive** data should meet a minimum standard established by the security team during a threat assessment and annual reviews
+* **Sensitive** data should be secured at rest and in-transit using standard encryption protocols (e.g. cryptography libraries, OS level key management systems, https, etc…)
+* Cryptography of **sensitive** data should meet a minimum standard established by the security team during a threat assessment and annual reviews
 
-#### 2.4 – Passwords
+#### Passwords
 
-* 2.4.1: Passwords used to decrypt content should adhere to security team recommendations during a threat assessment and annual reviews.
+* Passwords used to decrypt content should adhere to security team recommendations during a threat assessment and annual reviews.
 
-### 3 – Logging & Error Handling
+### Logging & Error Handling
 
-#### 3.1 – Logging
+#### Logging
 
-* 3.1.1: Secrets and **sensitive** data should not be logged
-* 3.1.2: Console logging should be removed from production code using linters
+* Secrets and **sensitive** data should not be logged
+* Console logging should be removed from production code using linters
 
-#### 3.2 – Error Handling
+#### Error Handling
 
-* 3.2.1: All errors should be handled
-* 3.2.2: Errors should not leak data and be made more generic. This is especially important for code which handles data classified as **sensitive**.
-* 3.2.3: Production versions of applications shall have logging disabled
+* All errors should be handled
+* Errors should not leak data and be made more generic. This is especially important for code which handles data classified as **sensitive**.
+* Production versions of applications shall have logging disabled
 
-### 4 – Third Party Integrations & Applications
+### Third Party Integrations & Applications
 
-#### 4.1 – Authentication and Authorization
+#### Authentication and Authorization
 
-* 4.1.1: Implement access controls and authentication mechanisms for accessing external data
-* 4.1.2: Store and manage API keys securely when accessing external sources
-* 4.1.3: API keys used in client applications shall have a reduced scope adhering to Principle of Least Privilege
-* 4.1.4: If an API key is not intended to be publicly accessible, do not use it in a client application
+* Implement access controls and authentication mechanisms for accessing external data
+* Store and manage API keys securely when accessing external sources
+* API keys used in client applications shall have a reduced scope adhering to Principle of Least Privilege
+* If an API key is not intended to be publicly accessible, do not use it in a client application
 
-#### 4.2 – Integration/Application Integrity
+#### Integration/Application Integrity
 
-* 4.2.1: Monitor integrations/applications for changes and security issues.
+* Monitor integrations/applications for changes and security issues.
 
-#### 4.3 – Permissions
+#### Permissions
 
-* 4.3.1: All applications/dapps/snaps shall adhere to the following to Principle of Least Privilege with a default state of allowing no permissions
-* 4.3.2: Users shall provide consent for required permissions of applications/dapps/snaps
+* All applications/dapps/snaps shall adhere to the following to Principle of Least Privilege with a default state of allowing no permissions
+* Users shall provide consent for required permissions of applications/dapps/snaps
 
-### 5 – Dependency Management
+### Dependency Management
 
-#### 5.1 – Dependency Integrity
+#### Dependency Integrity
 
-* 5.1.1: Use Dependabot to keep all dependencies up to date and to automate checks for updates
-* 5.1.2: Pin dependency versions or use a yarn.lock file
+* Use Dependabot to keep all dependencies up to date and to automate checks for updates
+* Pin dependency versions or use a yarn.lock file
 
-#### 5.2 – Avoid Deprecated and Unmaintained Packages
+#### Avoid Deprecated and Unmaintained Packages
 
-* 5.2.1: Using Socket.dev to check the health and maintenance status of dependencies and seek alternatives when necessary
+* Using Socket.dev to check the health and maintenance status of dependencies and seek alternatives when necessary
 
-#### 5.3 – Review Dependency Licenses
+#### Review Dependency Licenses
 
-* 5.3.1: Ensure dependencies' licenses align with your project's requirements
+* Ensure dependencies' licenses align with your project's requirements
 
-#### 5.4 – Reduce Dependencies and Keep Them Minimal
+#### Reduce Dependencies and Keep Them Minimal
 
-* 5.4.1: Minimize dependencies to reduce potential vulnerabilities
+* Minimize dependencies to reduce potential vulnerabilities
 
-#### 5.5 – Audit and Monitor Dependencies
+#### Audit and Monitor Dependencies
 
-* 5.5.1: Projects should use the npm audit, Dependabot and Socket.dev tooling for periodic automated auditing of dependencies
+* Projects should use the npm audit, Dependabot and Socket.dev tooling for periodic automated auditing of dependencies
 
-#### 5.6 – LavaMoat
+#### LavaMoat
 
-* 5.6.1: LavaMoat allow-scripts should be enabled on all projects
-* 5.6.2: LavaMoat runtime should be enabled on all projects
+* LavaMoat allow-scripts should be enabled on all projects
+* LavaMoat runtime should be enabled on all projects
 
-### 6 – Operations & Infrastructure
+### Operations & Infrastructure
 
-#### 6.1 – Project secrets
+#### Project secrets
 
-* 6.1.1: Project secrets should be generated and shared using a password management system (1Password) and access to that system should follow the Principle of Least Authority
-* 6.1.2: Build systems needing access to project secrets should store secrets in specific secret storage and obscured once placed into system
+* Project secrets should be generated and shared using a password management system (1Password) and access to that system should follow the Principle of Least Authority
+* Build systems needing access to project secrets should store secrets in specific secret storage and obscured once placed into system
 
-#### 6.2 – Application Integrity
+#### Application Integrity
 
-* 6.2.1: Application should be distributed through approved store portals (GitHub, App Store, Play Store, Firefox Store, Chrome Store)
-* 6.2.2: Each distribution channel shall have provide release verifiability (certificate signing approval, hash verification)
+* Application should be distributed through approved store portals (GitHub, App Store, Play Store, Firefox Store, Chrome Store)
+* Each distribution channel shall have provide release verifiability (certificate signing approval, hash verification)
 
-#### 6.3 – Auditability
+#### Auditability
 
-* 6.3.1: All systems supporting the application shall have capability to audit modifications to the system
+* All systems supporting the application shall have capability to audit modifications to the system

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -140,7 +140,7 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
       - If you've investigated a warning and found that it's not indicative of a malicious dependency, ignore it with a bot comment and explain your investigation with a short comment
       - Contact the security team if you're unsure how to investigate something, or if you'd like to disable a warning category
 
-#### LavaMoat
+#### LavaMoat (JavaScript projects only)
 
 - LavaMoat `allow-scripts` should be enabled on all projects
   - This project relies upon install scripts being disabled in your package manager. This can be verified by adding the dependency `@lavamoat/preinstall-always-fail`, which will cause installation to fail if scripts are enabled.

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -18,119 +18,119 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 
 #### Data Validation and Sanitization
 
-* Always validate and sanitize user inputs and reject any input that does not pass validation, such as:
-   1. Checking the type is what we expect: (e.g. is a javascript object being passed in when a string is expected)
-   2. Checking if the value is what within a range we expect: (e.g. is a negative number being provided when a positive one is expected)
-   3. Checking if the format is what we expect: (e.g. do we expect a `0x` prefixed hex string but an alphanumeric string is provided instead)
-   4. Checking if a value matches an allowed set of constants (e.g. is the value one of the few possible numbers we expect)
-* Validate and sanitize data from external sources before rendering it in the application's UI
-* Preference should be given to libraries and frameworks that support input validation
-* Avoid dynamic code execution with untrusted data to prevent injection attacks
+- Always validate and sanitize user inputs and reject any input that does not pass validation, such as:
+  1.  Checking the type is what we expect: (e.g. is a javascript object being passed in when a string is expected)
+  2.  Checking if the value is what within a range we expect: (e.g. is a negative number being provided when a positive one is expected)
+  3.  Checking if the format is what we expect: (e.g. do we expect a `0x` prefixed hex string but an alphanumeric string is provided instead)
+  4.  Checking if a value matches an allowed set of constants (e.g. is the value one of the few possible numbers we expect)
+- Validate and sanitize data from external sources before rendering it in the application's UI
+- Preference should be given to libraries and frameworks that support input validation
+- Avoid dynamic code execution with untrusted data to prevent injection attacks
 
 #### Content Security
 
-* Verify the content type of external data to ensure it matches expectations
-* Enforce proper type checking, file type validation for file/media uploads and rendering third party content
-* Implement Content Security Policies (CSP) to mitigate XSS attacks when rendering external data
+- Verify the content type of external data to ensure it matches expectations
+- Enforce proper type checking, file type validation for file/media uploads and rendering third party content
+- Implement Content Security Policies (CSP) to mitigate XSS attacks when rendering external data
 
 #### Data Serialization
 
-* Recommend using pure data formats such as CSV, JSON for serialization to avoid deserialization attacks
+- Recommend using pure data formats such as CSV, JSON for serialization to avoid deserialization attacks
 
 ### Data Persistence & Encryption
 
 #### Data Classification
 
-* Classify the data in your application into at least two groups:
-* **Non-sensitive** data (e.g. publicly available, transactions, app theme settings, etc…)
-* **Sensitive** data (e.g. passwords, keys)
+- Classify the data in your application into at least two groups:
+- **Non-sensitive** data (e.g. publicly available, transactions, app theme settings, etc…)
+- **Sensitive** data (e.g. passwords, keys)
 
 #### Data Security
 
-* Encrypt **sensitive** data prior to persisting
-* Limit the amount of time **sensitive** data is decrypted
-* Do not bundle API tokens in client side applications unless you intend for them to be publicly accessible
+- Encrypt **sensitive** data prior to persisting
+- Limit the amount of time **sensitive** data is decrypted
+- Do not bundle API tokens in client side applications unless you intend for them to be publicly accessible
 
 #### Encryption
 
-* **Sensitive** data should be secured at rest and in-transit using standard encryption protocols (e.g. cryptography libraries, OS level key management systems, https, etc…)
-* Cryptography of **sensitive** data should meet a minimum standard established by the security team during a threat assessment and annual reviews
+- **Sensitive** data should be secured at rest and in-transit using standard encryption protocols (e.g. cryptography libraries, OS level key management systems, https, etc…)
+- Cryptography of **sensitive** data should meet a minimum standard established by the security team during a threat assessment and annual reviews
 
 #### Passwords
 
-* Passwords used to decrypt content should adhere to security team recommendations during a threat assessment and annual reviews.
+- Passwords used to decrypt content should adhere to security team recommendations during a threat assessment and annual reviews.
 
 ### Logging & Error Handling
 
 #### Logging
 
-* Secrets and **sensitive** data should not be logged
-* Console logging should be removed from production code using linters
+- Secrets and **sensitive** data should not be logged
+- Console logging should be removed from production code using linters
 
 #### Error Handling
 
-* All errors should be handled
-* Errors should not leak data and be made more generic. This is especially important for code which handles data classified as **sensitive**.
-* Production versions of applications shall have logging disabled
+- All errors should be handled
+- Errors should not leak data and be made more generic. This is especially important for code which handles data classified as **sensitive**.
+- Production versions of applications shall have logging disabled
 
 ### Third Party Integrations & Applications
 
 #### Authentication and Authorization
 
-* Implement access controls and authentication mechanisms for accessing external data
-* Store and manage API keys securely when accessing external sources
-* API keys used in client applications shall have a reduced scope adhering to Principle of Least Privilege
-* If an API key is not intended to be publicly accessible, do not use it in a client application
+- Implement access controls and authentication mechanisms for accessing external data
+- Store and manage API keys securely when accessing external sources
+- API keys used in client applications shall have a reduced scope adhering to Principle of Least Privilege
+- If an API key is not intended to be publicly accessible, do not use it in a client application
 
 #### Integration/Application Integrity
 
-* Monitor integrations/applications for changes and security issues.
+- Monitor integrations/applications for changes and security issues.
 
 #### Permissions
 
-* All applications/dapps/snaps shall adhere to the following to Principle of Least Privilege with a default state of allowing no permissions
-* Users shall provide consent for required permissions of applications/dapps/snaps
+- All applications/dapps/snaps shall adhere to the following to Principle of Least Privilege with a default state of allowing no permissions
+- Users shall provide consent for required permissions of applications/dapps/snaps
 
 ### Dependency Management
 
 #### Dependency Integrity
 
-* Use Dependabot to keep all dependencies up to date and to automate checks for updates
-* Pin dependency versions or use a yarn.lock file
+- Use Dependabot to keep all dependencies up to date and to automate checks for updates
+- Pin dependency versions or use a yarn.lock file
 
 #### Avoid Deprecated and Unmaintained Packages
 
-* Using Socket.dev to check the health and maintenance status of dependencies and seek alternatives when necessary
+- Using Socket.dev to check the health and maintenance status of dependencies and seek alternatives when necessary
 
 #### Review Dependency Licenses
 
-* Ensure dependencies' licenses align with your project's requirements
+- Ensure dependencies' licenses align with your project's requirements
 
 #### Reduce Dependencies and Keep Them Minimal
 
-* Minimize dependencies to reduce potential vulnerabilities
+- Minimize dependencies to reduce potential vulnerabilities
 
 #### Audit and Monitor Dependencies
 
-* Projects should use the npm audit, Dependabot and Socket.dev tooling for periodic automated auditing of dependencies
+- Projects should use the npm audit, Dependabot and Socket.dev tooling for periodic automated auditing of dependencies
 
 #### LavaMoat
 
-* LavaMoat allow-scripts should be enabled on all projects
-* LavaMoat runtime should be enabled on all projects
+- LavaMoat allow-scripts should be enabled on all projects
+- LavaMoat runtime should be enabled on all projects
 
 ### Operations & Infrastructure
 
 #### Project secrets
 
-* Project secrets should be generated and shared using a password management system (1Password) and access to that system should follow the Principle of Least Authority
-* Build systems needing access to project secrets should store secrets in specific secret storage and obscured once placed into system
+- Project secrets should be generated and shared using a password management system (1Password) and access to that system should follow the Principle of Least Authority
+- Build systems needing access to project secrets should store secrets in specific secret storage and obscured once placed into system
 
 #### Application Integrity
 
-* Application should be distributed through approved store portals (GitHub, App Store, Play Store, Firefox Store, Chrome Store)
-* Each distribution channel shall have provide release verifiability (certificate signing approval, hash verification)
+- Application should be distributed through approved store portals (GitHub, App Store, Play Store, Firefox Store, Chrome Store)
+- Each distribution channel shall have provide release verifiability (certificate signing approval, hash verification)
 
 #### Auditability
 
-* All systems supporting the application shall have capability to audit modifications to the system
+- All systems supporting the application shall have capability to audit modifications to the system

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -169,7 +169,3 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 
 - Application should be distributed through approved store portals (GitHub, App Store, Play Store, Firefox Store, Chrome Store)
 - Each distribution channel shall have provide release verifiability (certificate signing approval, hash verification)
-
-#### Auditability
-
-- All systems supporting the application shall have capability to audit modifications to the system

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -45,7 +45,7 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 
 - Avoid dynamic code execution with untrusted data
 
-  Dynamic code execution of untrusted data can allow for injection attacks. Prevent this by avoiding dynamic code execution completely where possible, but especially when the code being run was derived from untrusted data.
+  Dynamic code execution of untrusted data can allow for injection attacks. If possible, avoid dynamic code execution completely. If you require dynamic code execution, consult with the security team on how to do this safely.
 
   Examples of dynamic code execution:
 

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -97,7 +97,7 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 
   For example, the error "Invalid hex data: \_\_\_\_" might indadvertantly leak a private key. Instead the error could be made more generic ("Invalid hex data"), or you could describe the problem without embedding the data ("Invalid hex data; missing 0x prefix").
 
-### Third Party Integrations & Applications
+### Third Party Integrations
 
 #### Authentication and Authorization
 
@@ -109,6 +109,8 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 #### Integration/Application Integrity
 
 - Monitor integrations/applications for changes and security issues
+
+### Third Party Applications
 
 #### Permissions
 

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -119,7 +119,6 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 
 #### Dependency Integrity
 
-- Use Dependabot to keep all dependencies up to date and to automate checks for updates
 - Use a lockfile or pinned dependencies to maintain control over which version of each dependency is used
 
 #### Avoid Deprecated and Unmaintained Packages

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -39,6 +39,10 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
     - Some libraries do this automatically (e.g. React)
   - URL-encode data before including it in a URL
 
+- When accepting a URI as input, ensure the scheme matches expectations
+
+  For example, a URL for a website or API would typically have a scheme of `https`.
+
 - Avoid dynamic code execution with untrusted data
 
   Dynamic code execution of untrusted data can allow for injection attacks. Prevent this by avoiding dynamic code execution completely where possible, but especially when the code being run was derived from untrusted data.

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -1,0 +1,91 @@
+# Secure Coding Guidelines
+
+## Purpose
+
+The secure coding guidelines are a reference to develop, deliver and maintain software in a secure manner.
+
+## Scope
+
+These guidelines apply to developers building client based applications at MetaMask.
+
+## References
+
+The guidelines in this policy were gathered from concepts on the [OWASP Top 10 Site](https://owasp.org/www-project-top-ten/) and modified to meet the client applications being developed at MetaMask.
+
+## Guidelines
+
+This document identifies six categories developers should reference when working on client based applications. 
+
+1. User Input:
+   1. Processing User Inputs:
+      1. Always validate and sanitize user inputs
+      2. Preference should be given to libraries and frameworks that support input validation
+   2. Data Serialization:
+      1. Recommend using pure data formats such as JSON for serialization to avoid deserialization attacks
+
+2. Data Persistence & Encryption:
+    1. Data Classification:
+        1. Classify the data in your application into at least two groups:
+          1. Non-sensitive data (e.g. publicly available, transactions, tokens, etc…)
+          2. Sensitive data   (e.g. passwords, keys)
+    2. Data Security:
+        1. Encrypt sensitive data prior to persisting
+        2. Limit the amount of time sensitive data is decrypted
+    3. Encryption:
+        1. Sensitive data should be secured at rest and in-transit using standard encryption protocols (e.g. cryptography libraries, OS level key management systems, https, etc…)
+        2. Cryptography of sensitive data should meet a minimum standard established by the security team during a threat assessment and annual reviews
+    4. Passwords:
+        1. Passwords used to decrypt content should adhere to security team recommendations during a threat assessment and annual reviews.
+
+3. Logging & Error Handling:
+    1. Logging:
+        1. Secrets and sensitive data should not be logged
+        2. Console logging should be removed from production code using linters
+    2. Error Handling:
+        1. All errors should be handled
+        2. Errors should not leak data and be made more generic
+        3. Production versions of applications shall have logging disabled
+
+4. 3rd Party Data & Applications:
+    1. Data Validation and Sanitization:
+        1. Validate and sanitize data from external sources before rendering it in the application's UI
+        2. Avoid dynamic code execution with untrusted data to prevent injection attacks
+    2. Content Security:
+        1. Verify the content type of external data to ensure it matches expectations
+        2. Enforce proper type checking, file type validation for file/media uploads and rendering 3rd party content
+        3. Implement Content Security Policies (CSP) to mitigate XSS attacks when rendering external data
+    3. Authentication and Authorization:
+        1. Implement access controls and authentication mechanisms for accessing external data
+        2. Store and manage API keys securely when accessing external sources
+        3. API keys used in client applications shall have a reduced scope adhering to Principle of Least Privilege
+    4. Data Integrity:
+        1. Monitor external data sources for changes and security issues.
+    5. Permissions:
+        1. All applications/dapps/snaps shall adhere to the following to Principle of Least Privilege with a default state of allowing no permissions
+        2. Users shall provide consent for required permissions of applications/dapps/snaps
+
+5. Dependency Management:
+    1. Dependency Integrity:
+        1. Keep all dependencies up to date, using tools to automate checks for updates
+        2. Pin dependency versions or use a yarn.lock file
+    2. Avoid Deprecated and Unmaintained Packages:
+        1. Using Socket.dev to check the health and maintenance status of dependencies and seek alternatives when necessary  
+    3. Review Dependency Licenses:
+        1. Ensure dependencies' licenses align with your project's requirements
+    4. Reduce Dependencies and Keep Them Minimal:
+        1. Minimize dependencies to reduce potential vulnerabilities
+    5. Audit and Monitor Dependencies:
+        1. Projects should use the npm audit, Dependabot and Socket.dev tooling for periodic automated auditing of dependencies
+    6. LavaMoat:
+        1. LavaMoat allow-scripts should be enabled on all projects
+        2. LavaMoat runtime should be enabled on all projects
+
+6. Operations & Infrastructure:
+    1. Project secrets:
+        1. Project secrets should be generated and shared using a password management system (1Password) and access to that system should follow the Principle of Least Authority
+       2. Build systems needing access to project secrets should store secrets in specific secret storage and obscured once placed into system
+    2. Application Integrity:
+        1. Application should be distributed through approved store portals (GitHub, App Store, Play Store, Firefox Store, Chrome Store)
+        2. Each distribution channel shall have provide release verifiability (certificate signing approval, hash verification)       
+    3. Auditability:
+       1. All systems supporting the application shall have capability to audit modifications to the system 

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -79,11 +79,11 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 #### Encryption
 
 - **Sensitive** data should be secured at rest and in-transit using standard encryption protocols (e.g. cryptography libraries, OS level key management systems, https, etc.)
-- Cryptography of **sensitive** data should meet a minimum standard established by the security team during a threat assessment and annual reviews
+- Cryptography of **sensitive** data should meet a minimum standard established by the security team
 
 #### Passwords
 
-- Passwords used to decrypt content should adhere to security team recommendations during a threat assessment and annual reviews
+- Passwords used to decrypt content should adhere to security team recommendations
 
 ### Logging & Error Handling
 

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -75,7 +75,6 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 
 - Encrypt **sensitive** data prior to persisting
 - Limit the amount of time **sensitive** data is decrypted
-- Do not bundle API tokens in client side applications unless you intend for them to be publicly accessible
 
 #### Encryption
 
@@ -106,7 +105,7 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 - Implement access controls and authentication mechanisms for accessing external data
 - Store and manage API keys securely when accessing external sources
 - API keys used in client applications shall have a reduced scope adhering to Principle of Least Privilege
-- If an API key is not intended to be publicly accessible, do not use it in a client application
+- Do not bundle API tokens in client side applications unless you intend for them to be publicly accessible
 
 #### Integration/Application Integrity
 

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -41,7 +41,7 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 
 - When accepting a URI as input, ensure the scheme matches expectations
 
-  For example, a URL for a website or API would typically have a scheme of `https`.
+  For example, a URL for a website or API would typically have a scheme of `https`
 
 - Avoid dynamic code execution with untrusted data
 
@@ -94,7 +94,7 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 #### Error Handling
 
 - All errors should be handled
-- Errors should not leak data and be made more generic. This is especially important for code which handles data classified as **sensitive**.
+- Errors should not leak data and be made more generic. This is especially important for code which handles data classified as **sensitive**
 - Production versions of applications shall have logging disabled
 
 ### Third Party Integrations & Applications
@@ -108,7 +108,7 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 
 #### Integration/Application Integrity
 
-- Monitor integrations/applications for changes and security issues.
+- Monitor integrations/applications for changes and security issues
 
 #### Permissions
 

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -14,9 +14,10 @@ The guidelines in this policy were gathered from concepts on the [OWASP Top 10 S
 
 ## Guidelines
 
-This document identifies six categories developers should reference when working on client based applications. 
+This document identifies six categories developers should reference when working on client based applications.
 
 1. User Input:
+
    1. Processing User Inputs:
       1. Always validate and sanitize user inputs
       2. Preference should be given to libraries and frameworks that support input validation
@@ -24,68 +25,72 @@ This document identifies six categories developers should reference when working
       1. Recommend using pure data formats such as JSON for serialization to avoid deserialization attacks
 
 2. Data Persistence & Encryption:
-    1. Data Classification:
-        1. Classify the data in your application into at least two groups:
-          1. Non-sensitive data (e.g. publicly available, transactions, tokens, etc…)
-          2. Sensitive data   (e.g. passwords, keys)
-    2. Data Security:
-        1. Encrypt sensitive data prior to persisting
-        2. Limit the amount of time sensitive data is decrypted
-    3. Encryption:
-        1. Sensitive data should be secured at rest and in-transit using standard encryption protocols (e.g. cryptography libraries, OS level key management systems, https, etc…)
-        2. Cryptography of sensitive data should meet a minimum standard established by the security team during a threat assessment and annual reviews
-    4. Passwords:
-        1. Passwords used to decrypt content should adhere to security team recommendations during a threat assessment and annual reviews.
+
+   1. Data Classification:
+      1. Classify the data in your application into at least two groups:
+      1. Non-sensitive data (e.g. publicly available, transactions, tokens, etc…)
+      1. Sensitive data (e.g. passwords, keys)
+   2. Data Security:
+      1. Encrypt sensitive data prior to persisting
+      2. Limit the amount of time sensitive data is decrypted
+   3. Encryption:
+      1. Sensitive data should be secured at rest and in-transit using standard encryption protocols (e.g. cryptography libraries, OS level key management systems, https, etc…)
+      2. Cryptography of sensitive data should meet a minimum standard established by the security team during a threat assessment and annual reviews
+   4. Passwords:
+      1. Passwords used to decrypt content should adhere to security team recommendations during a threat assessment and annual reviews.
 
 3. Logging & Error Handling:
-    1. Logging:
-        1. Secrets and sensitive data should not be logged
-        2. Console logging should be removed from production code using linters
-    2. Error Handling:
-        1. All errors should be handled
-        2. Errors should not leak data and be made more generic
-        3. Production versions of applications shall have logging disabled
+
+   1. Logging:
+      1. Secrets and sensitive data should not be logged
+      2. Console logging should be removed from production code using linters
+   2. Error Handling:
+      1. All errors should be handled
+      2. Errors should not leak data and be made more generic
+      3. Production versions of applications shall have logging disabled
 
 4. 3rd Party Data & Applications:
-    1. Data Validation and Sanitization:
-        1. Validate and sanitize data from external sources before rendering it in the application's UI
-        2. Avoid dynamic code execution with untrusted data to prevent injection attacks
-    2. Content Security:
-        1. Verify the content type of external data to ensure it matches expectations
-        2. Enforce proper type checking, file type validation for file/media uploads and rendering 3rd party content
-        3. Implement Content Security Policies (CSP) to mitigate XSS attacks when rendering external data
-    3. Authentication and Authorization:
-        1. Implement access controls and authentication mechanisms for accessing external data
-        2. Store and manage API keys securely when accessing external sources
-        3. API keys used in client applications shall have a reduced scope adhering to Principle of Least Privilege
-    4. Data Integrity:
-        1. Monitor external data sources for changes and security issues.
-    5. Permissions:
-        1. All applications/dapps/snaps shall adhere to the following to Principle of Least Privilege with a default state of allowing no permissions
-        2. Users shall provide consent for required permissions of applications/dapps/snaps
+
+   1. Data Validation and Sanitization:
+      1. Validate and sanitize data from external sources before rendering it in the application's UI
+      2. Avoid dynamic code execution with untrusted data to prevent injection attacks
+   2. Content Security:
+      1. Verify the content type of external data to ensure it matches expectations
+      2. Enforce proper type checking, file type validation for file/media uploads and rendering 3rd party content
+      3. Implement Content Security Policies (CSP) to mitigate XSS attacks when rendering external data
+   3. Authentication and Authorization:
+      1. Implement access controls and authentication mechanisms for accessing external data
+      2. Store and manage API keys securely when accessing external sources
+      3. API keys used in client applications shall have a reduced scope adhering to Principle of Least Privilege
+   4. Data Integrity:
+      1. Monitor external data sources for changes and security issues.
+   5. Permissions:
+      1. All applications/dapps/snaps shall adhere to the following to Principle of Least Privilege with a default state of allowing no permissions
+      2. Users shall provide consent for required permissions of applications/dapps/snaps
 
 5. Dependency Management:
-    1. Dependency Integrity:
-        1. Keep all dependencies up to date, using tools to automate checks for updates
-        2. Pin dependency versions or use a yarn.lock file
-    2. Avoid Deprecated and Unmaintained Packages:
-        1. Using Socket.dev to check the health and maintenance status of dependencies and seek alternatives when necessary  
-    3. Review Dependency Licenses:
-        1. Ensure dependencies' licenses align with your project's requirements
-    4. Reduce Dependencies and Keep Them Minimal:
-        1. Minimize dependencies to reduce potential vulnerabilities
-    5. Audit and Monitor Dependencies:
-        1. Projects should use the npm audit, Dependabot and Socket.dev tooling for periodic automated auditing of dependencies
-    6. LavaMoat:
-        1. LavaMoat allow-scripts should be enabled on all projects
-        2. LavaMoat runtime should be enabled on all projects
+
+   1. Dependency Integrity:
+      1. Keep all dependencies up to date, using tools to automate checks for updates
+      2. Pin dependency versions or use a yarn.lock file
+   2. Avoid Deprecated and Unmaintained Packages:
+      1. Using Socket.dev to check the health and maintenance status of dependencies and seek alternatives when necessary
+   3. Review Dependency Licenses:
+      1. Ensure dependencies' licenses align with your project's requirements
+   4. Reduce Dependencies and Keep Them Minimal:
+      1. Minimize dependencies to reduce potential vulnerabilities
+   5. Audit and Monitor Dependencies:
+      1. Projects should use the npm audit, Dependabot and Socket.dev tooling for periodic automated auditing of dependencies
+   6. LavaMoat:
+      1. LavaMoat allow-scripts should be enabled on all projects
+      2. LavaMoat runtime should be enabled on all projects
 
 6. Operations & Infrastructure:
-    1. Project secrets:
-        1. Project secrets should be generated and shared using a password management system (1Password) and access to that system should follow the Principle of Least Authority
-       2. Build systems needing access to project secrets should store secrets in specific secret storage and obscured once placed into system
-    2. Application Integrity:
-        1. Application should be distributed through approved store portals (GitHub, App Store, Play Store, Firefox Store, Chrome Store)
-        2. Each distribution channel shall have provide release verifiability (certificate signing approval, hash verification)       
-    3. Auditability:
-       1. All systems supporting the application shall have capability to audit modifications to the system 
+   1. Project secrets:
+      1. Project secrets should be generated and shared using a password management system (1Password) and access to that system should follow the Principle of Least Authority
+      2. Build systems needing access to project secrets should store secrets in specific secret storage and obscured once placed into system
+   2. Application Integrity:
+      1. Application should be distributed through approved store portals (GitHub, App Store, Play Store, Firefox Store, Chrome Store)
+      2. Each distribution channel shall have provide release verifiability (certificate signing approval, hash verification)
+   3. Auditability:
+      1. All systems supporting the application shall have capability to audit modifications to the system

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -14,87 +14,123 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 
 ## Guidelines
 
-### 1. Input from Users and Third Party Services
+### 1 Input from Users and Third Party Services
 
-1.  Data Validation and Sanitization:
-    1. Always validate and sanitize user inputs and reject any input that does not pass validation, such as:
-       1. Checking the type is what we expect: (e.g. is a javascript object being passed in when a string is expected)
-       2. Checking if the value is what within a range we expect: (e.g. is a negative number being provided when a positive one is expected)
-       3. Checking if the format is what we expect: (e.g. do we expect a `0x` prefixed hex string but an alphanumeric string is provided instead)
-       4. Checking if a value matches an allowed set of constants (e.g. is the value one of the few possible numbers we expect)
-    2. Validate and sanitize data from external sources before rendering it in the application's UI
-    3. Preference should be given to libraries and frameworks that support input validation
-    4. Avoid dynamic code execution with untrusted data to prevent injection attacks
-2.  Content Security:
-    1. Verify the content type of external data to ensure it matches expectations
-    2. Enforce proper type checking, file type validation for file/media uploads and rendering 3rd party content
-    3. Implement Content Security Policies (CSP) to mitigate XSS attacks when rendering external data
-3.  Data Serialization:
-    1. Recommend using pure data formats such as CSV, JSON for serialization to avoid deserialization attacks
+#### 1.1 Data Validation and Sanitization
 
-### 2. Data Persistence & Encryption
+1. Always validate and sanitize user inputs and reject any input that does not pass validation, such as:
+   1. Checking the type is what we expect: (e.g. is a javascript object being passed in when a string is expected)
+   2. Checking if the value is what within a range we expect: (e.g. is a negative number being provided when a positive one is expected)
+   3. Checking if the format is what we expect: (e.g. do we expect a `0x` prefixed hex string but an alphanumeric string is provided instead)
+   4. Checking if a value matches an allowed set of constants (e.g. is the value one of the few possible numbers we expect)
+2. Validate and sanitize data from external sources before rendering it in the application's UI
+3. Preference should be given to libraries and frameworks that support input validation
+4. Avoid dynamic code execution with untrusted data to prevent injection attacks
 
-1.  Data Classification:
-    1. Classify the data in your application into at least two groups:
-    2. **Non-sensitive** data (e.g. publicly available, transactions, app theme settings, etc…)
-    3. **Sensitive** data (e.g. passwords, keys)
-2.  Data Security:
-    1. Encrypt **sensitive** data prior to persisting
-    2. Limit the amount of time **sensitive** data is decrypted
-    3. Do not bundle API tokens in client side applications unless you intend for them to be publicly accessible
-3.  Encryption:
-    1. **Sensitive** data should be secured at rest and in-transit using standard encryption protocols (e.g. cryptography libraries, OS level key management systems, https, etc…)
-    2. Cryptography of **sensitive** data should meet a minimum standard established by the security team during a threat assessment and annual reviews
-4.  Passwords:
-    1. Passwords used to decrypt content should adhere to security team recommendations during a threat assessment and annual reviews.
+#### 1.2 Content Security
 
-### 3. Logging & Error Handling
+1. Verify the content type of external data to ensure it matches expectations
+2. Enforce proper type checking, file type validation for file/media uploads and rendering 3rd party content
+3. Implement Content Security Policies (CSP) to mitigate XSS attacks when rendering external data
 
-1.  Logging:
-    1. Secrets and **sensitive** data should not be logged
-    2. Console logging should be removed from production code using linters
-2.  Error Handling:
-    1. All errors should be handled
-    2. Errors should not leak data and be made more generic. This is especially important for code which handles data classified as **sensitive**.
-    3. Production versions of applications shall have logging disabled
+#### 1.3 Data Serialization
 
-### 4. 3rd Party Integrations & Applications
+1. Recommend using pure data formats such as CSV, JSON for serialization to avoid deserialization attacks
 
-1.  Authentication and Authorization:
-    1. Implement access controls and authentication mechanisms for accessing external data
-    2. Store and manage API keys securely when accessing external sources
-    3. API keys used in client applications shall have a reduced scope adhering to Principle of Least Privilege
-    4. If an API key is not intended to be publicly accessible, do not use it in a client application
-2.  Integration/Application Integrity:
-    1. Monitor integrations/applications for changes and security issues.
-3.  Permissions:
-    1. All applications/dapps/snaps shall adhere to the following to Principle of Least Privilege with a default state of allowing no permissions
-    2. Users shall provide consent for required permissions of applications/dapps/snaps
+### 2 Data Persistence & Encryption
 
-### 5. Dependency Management
+#### 2.1 Data Classification
 
-1.  Dependency Integrity:
-    1. Use Dependabot to keep all dependencies up to date and to automate checks for updates
-    2. Pin dependency versions or use a yarn.lock file
-2.  Avoid Deprecated and Unmaintained Packages:
-    1. Using Socket.dev to check the health and maintenance status of dependencies and seek alternatives when necessary
-3.  Review Dependency Licenses:
-    1. Ensure dependencies' licenses align with your project's requirements
-4.  Reduce Dependencies and Keep Them Minimal:
-    1. Minimize dependencies to reduce potential vulnerabilities
-5.  Audit and Monitor Dependencies:
-    1. Projects should use the npm audit, Dependabot and Socket.dev tooling for periodic automated auditing of dependencies
-6.  LavaMoat:
-    1. LavaMoat allow-scripts should be enabled on all projects
-    2. LavaMoat runtime should be enabled on all projects
+1. Classify the data in your application into at least two groups:
+2. **Non-sensitive** data (e.g. publicly available, transactions, app theme settings, etc…)
+3. **Sensitive** data (e.g. passwords, keys)
 
-### 6. Operations & Infrastructure
+#### 2.2 Data Security
 
-1.  Project secrets:
-    1. Project secrets should be generated and shared using a password management system (1Password) and access to that system should follow the Principle of Least Authority
-    2. Build systems needing access to project secrets should store secrets in specific secret storage and obscured once placed into system
-2.  Application Integrity:
-    1. Application should be distributed through approved store portals (GitHub, App Store, Play Store, Firefox Store, Chrome Store)
-    2. Each distribution channel shall have provide release verifiability (certificate signing approval, hash verification)
-3.  Auditability:
-    1. All systems supporting the application shall have capability to audit modifications to the system
+1. Encrypt **sensitive** data prior to persisting
+2. Limit the amount of time **sensitive** data is decrypted
+3. Do not bundle API tokens in client side applications unless you intend for them to be publicly accessible
+
+#### 2.3 Encryption
+
+1. **Sensitive** data should be secured at rest and in-transit using standard encryption protocols (e.g. cryptography libraries, OS level key management systems, https, etc…)
+2. Cryptography of **sensitive** data should meet a minimum standard established by the security team during a threat assessment and annual reviews
+
+#### 2.4 Passwords
+
+1. Passwords used to decrypt content should adhere to security team recommendations during a threat assessment and annual reviews.
+
+### 3 Logging & Error Handling
+
+#### 3.1 Logging
+
+1. Secrets and **sensitive** data should not be logged
+2. Console logging should be removed from production code using linters
+
+#### 3.2 Error Handling
+
+1. All errors should be handled
+2. Errors should not leak data and be made more generic. This is especially important for code which handles data classified as **sensitive**.
+3. Production versions of applications shall have logging disabled
+
+### 4 3rd Party Integrations & Applications
+
+#### 4.1 Authentication and Authorization
+
+1. Implement access controls and authentication mechanisms for accessing external data
+2. Store and manage API keys securely when accessing external sources
+3. API keys used in client applications shall have a reduced scope adhering to Principle of Least Privilege
+4. If an API key is not intended to be publicly accessible, do not use it in a client application
+
+#### 4.2 Integration/Application Integrity
+
+1. Monitor integrations/applications for changes and security issues.
+
+#### 4.3 Permissions
+
+1. All applications/dapps/snaps shall adhere to the following to Principle of Least Privilege with a default state of allowing no permissions
+2. Users shall provide consent for required permissions of applications/dapps/snaps
+
+### 5 Dependency Management
+
+#### 5.1 Dependency Integrity
+
+1. Use Dependabot to keep all dependencies up to date and to automate checks for updates
+2. Pin dependency versions or use a yarn.lock file
+
+#### 5.2 Avoid Deprecated and Unmaintained Packages
+
+1. Using Socket.dev to check the health and maintenance status of dependencies and seek alternatives when necessary
+
+#### 5.3 Review Dependency Licenses
+
+1. Ensure dependencies' licenses align with your project's requirements
+
+#### 5.4 Reduce Dependencies and Keep Them Minimal
+
+1. Minimize dependencies to reduce potential vulnerabilities
+
+#### 5.5 Audit and Monitor Dependencies
+
+1. Projects should use the npm audit, Dependabot and Socket.dev tooling for periodic automated auditing of dependencies
+
+#### 5.6 LavaMoat
+
+1. LavaMoat allow-scripts should be enabled on all projects
+2. LavaMoat runtime should be enabled on all projects
+
+### 6 Operations & Infrastructure
+
+#### 6.1 Project secrets
+
+1. Project secrets should be generated and shared using a password management system (1Password) and access to that system should follow the Principle of Least Authority
+2. Build systems needing access to project secrets should store secrets in specific secret storage and obscured once placed into system
+
+#### 6.2 Application Integrity
+
+1. Application should be distributed through approved store portals (GitHub, App Store, Play Store, Firefox Store, Chrome Store)
+2. Each distribution channel shall have provide release verifiability (certificate signing approval, hash verification)
+
+#### 6.3 Auditability
+
+1. All systems supporting the application shall have capability to audit modifications to the system

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -102,7 +102,6 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 #### Authentication and Authorization
 
 - Store and manage API keys securely when accessing external sources
-- API keys used in client applications shall have a reduced scope adhering to Principle of Least Privilege
 - Do not bundle API tokens in client side applications unless you intend for them to be publicly accessible
 
 #### Integration/Application Integrity


### PR DESCRIPTION
The Secure Coding Guidelines document path in the table of contents is broken. The path has been updated and is valid.