### PR TITLE
TypeScript Guidelines - Types: Inference, Annotations, Assertions, Escape Hatches

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -563,7 +563,21 @@ exampleFunction('__proto__');
 
 #### If accompanied by a TODO comment, `@ts-expect-error` is acceptable to use for marking errors that have clear plans of being resolved
 
-<!-- TODO: Add example -->
+**Example <a id="example-43313247-4393-4966-b78e-378f636fedec"></a> ([🔗 permalink](#example-43313247-4393-4966-b78e-378f636fedec)):**
+
+✅
+
+```typescript
+// @ts-expect-error TODO: remove this annotation once the `Eip1193Provider` class is released, resolving thi provider misalignment issue.
+return new Web3Provider(provider);
+
+// TODO: Fix this by handling or eliminating the undefined case
+// @ts-expect-error This variable can be `undefined`, which would break here.
+```
+
+This recommendation applies to any disruptive change that creates many errors at once (e.g. dependency update, upstream refactor, package migration).
+
+See [this entry](https://github.com/MetaMask/core/blob/main/docs/package-migration-process-guide.md#4-resolve-or-todo-downstream-errors) in the core repo "package migration process guide," which recommends that complex or blocked errors should be annotated with a `// @ts-expect-error TODO:` comment, and then revisited once the disruptive change has been completed.
 
 #### Always avoid `any`
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -15,9 +15,9 @@ Note that this document assumes that the reader has a high level of familiarity 
 TypeScript provides a range of syntax for communicating type information with the compiler.
 
 - The compiler performs **type inference** on all types and values in the code.
-- The user can assign **type annotations** (`:`, `satisfies`) to override inferred types or add type constraints.
-- The user can add **type assertions** (`as`, `!`) to force the compiler to accept user-supplied types even if they contradicts the inferred types.
-- Finally, there are **escape hatches** that let type checking be disabled (`any`, `@ts-expect-error`) for a certain scope of code.
+- The user can assign **type annotations** (`satisfies`, `:`) to override inferred types or add type constraints.
+- The user can add **type assertions** (`!`, `as`) to force the compiler to accept user-supplied types even if they contradicts the inferred types.
+- Finally, there are **escape hatches** that let type checking be disabled (`@ts-expect-error`, `any`) for a certain scope of code.
 
 The order of this list represents the general order of preference for using these features.
 
@@ -509,7 +509,7 @@ This is often the case when downstream consumers of the code are using JavaScrip
 
 🚫
 
-> **Error:** This comparison appears to be unintentional because the types '`0x${string}`' and '"\_\_proto\_\_"' have no overlap.ts(2367)
+> **Error:** This comparison appears to be unintentional because the types '\`0x${string}\`' and '"\_\_proto\_\_"' have no overlap.ts(2367)
 
 ```typescript
 function exampleFunction(chainId: `0x${string}`) {
@@ -522,7 +522,7 @@ function exampleFunction(chainId: `0x${string}`) {
 
 🚫
 
-> **Error:** Argument of type '"\_\_proto\_\_"' is not assignable to parameter of type '`0x${string}`'.ts(2345)
+> **Error:** Argument of type '"\_\_proto\_\_"' is not assignable to parameter of type '\`0x${string}\`'.ts(2345)
 
 ```typescript
 exampleFunction('__proto__');

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -25,7 +25,7 @@ There are several reasons for this:
 
 🚫 Type declarations
 
-```ts
+```typescript
 const name: string = 'METAMASK'; // Type 'string'
 
 const BUILT_IN_NETWORKS = new Map<string, `0x${string}`>([
@@ -36,7 +36,7 @@ const BUILT_IN_NETWORKS = new Map<string, `0x${string}`>([
 
 ✅ Type inferences
 
-```ts
+```typescript
 const name = 'METAMASK'; // Type 'METAMASK'
 
 const BUILT_IN_NETWORKS = {
@@ -47,7 +47,7 @@ const BUILT_IN_NETWORKS = {
 
 #### Example: To annotate or not to annotate
 
-```ts
+```typescript
 type TransactionMeta = TransactionBase &
   (
     | {
@@ -73,7 +73,7 @@ this.messagingSystem.publish(
 
 🚫 Add type annotation
 
-```ts
+```typescript
 // Type 'TransactionMeta'
 const updatedTransactionMeta: TransactionMeta = {
   ...transactionMeta,
@@ -83,7 +83,7 @@ const updatedTransactionMeta: TransactionMeta = {
 
 ✅ Add `as const` and leave to inference
 
-```ts
+```typescript
 // Type narrower than 'TransactionMeta': { status: TransactionStatus.rejected; ... }
 // (doesn't include 'error' property)
 const updatedTransactionMeta = {
@@ -104,7 +104,7 @@ There is a clear exception to the above: if an explicit type annotation or asser
 
 🚫
 
-```ts
+```typescript
 const chainId: string = this.messagingSystem(
   'NetworkController:getProviderConfig',
 ).chainId; // Type 'string'
@@ -112,7 +112,7 @@ const chainId: string = this.messagingSystem(
 
 ✅
 
-```ts
+```typescript
 const chainId = this.messagingSystem(
   'NetworkController:getProviderConfig',
 ).chainId; // Type '`0x${string}`'
@@ -124,14 +124,14 @@ This is one case where type inference is unable to reach a useful conclusion wit
 
 🚫
 
-```ts
+```typescript
 const tokens = []; // Type 'any[]'
 const tokensMap = new Map(); // Type 'Map<any, any>'
 ```
 
 ✅
 
-```ts
+```typescript
 const tokens: string[] = []; // Type 'string[]'
 const tokensMap = new Map<string, Token>(); // Type 'Map<string, Token>'
 ```
@@ -140,7 +140,7 @@ const tokensMap = new Map<string, Token>(); // Type 'Map<string, Token>'
 
 <!-- TODO: Add explanation and examples -->
 
-```ts
+```typescript
 function isSomeInterface(x: unknown): x is SomeInterface {
   return (
     'name' in x &&
@@ -211,7 +211,7 @@ Otherwise, only mocking the properties needed in the test improves readability b
 
 <!-- TODO: Add examples -->
 
-```ts
+```typescript
 const handler:
   | ((payload_0: ComposableControllerState, payload_1: Patch[]) => void)
   | ((payload_0: any, payload_1: Patch[]) => void); // Type of 'payload_0': 'any'
@@ -236,7 +236,7 @@ Some generic types use `any` as a default generic argument. This can silently in
 
 🚫
 
-```ts
+```typescript
 const NETWORKS = new Map({
   mainnet: '0x1',
   goerli: '0x5',
@@ -251,7 +251,7 @@ mockGetNetworkConfigurationByNetworkClientId.mockImplementation(
 
 ✅
 
-```ts
+```typescript
 const NETWORKS = new Map<string, `0x${string}`>({
   mainnet: '0x1',
   goerli: '0x5',
@@ -276,7 +276,7 @@ In most type errors involving property access or runtime property assignment, `a
 
 🚫
 
-```ts
+```typescript
 for (const key of getKnownPropertyNames(this.internalConfig)) {
   (this as any)[key] = this.internalConfig[key];
 }
@@ -288,7 +288,7 @@ delete addressBook[chainId as any];
 
 ✅
 
-```ts
+```typescript
 for (const key of getKnownPropertyNames(this.config)) {
   (this as unknown as typeof this.config)[key] = this.config[key];
 }
@@ -300,20 +300,20 @@ However, when assigning to a generic type, using `as any` is the only solution.
 
 🚫
 
-```ts
+```typescript
 (state as RateLimitState<RateLimitedApis>).requests[api][origin] = previous + 1;
 // is generic and can only be indexed for reading.ts(2862)
 ```
 
 ✅
 
-```ts
+```typescript
 (state as any).requests[api][origin] = previous + 1;
 ```
 
 Even in this case, however, `any` usage might be avoidable by using `Object.assign` or spread operator syntax instead of assignment.
 
-```ts
+```typescript
 Object.assign(state, {
   requests: {
     ...state.requests,
@@ -334,7 +334,7 @@ Object.assign(state, {
 
 ✅
 
-```ts
+```typescript
 class BaseController<
   ...,
   messenger extends RestrictedControllerMessenger<N, any, any, string, string>
@@ -362,7 +362,7 @@ Although TypeScript is capable of inferring return types, adding them explicitly
 
 🚫
 
-```ts
+```typescript
 async function removeAccount(address: Hex) {
   const keyring = await this.getKeyringForAccount(address);
 
@@ -379,7 +379,7 @@ async function removeAccount(address: Hex) {
 
 ✅
 
-```ts
+```typescript
 async function removeAccount(address: Hex): Promise<KeyringControllerState> {
   const keyring = await this.getKeyringForAccount(address);
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -2,13 +2,320 @@
 
 These guidelines specifically apply to TypeScript.
 
-## Provide explicit return types for functions/methods
+## Types
+
+### Type Inference
+
+TypeScript is very good at inferring types. A well-maintained codebase can provide strict type safety with explicit type annotations being the exception rather than the rule.
+
+When writing TypeScript, function and class signatures, and types that express the domain model of the codebase will require explicit definitions and annotations.
+
+However, for other types and values that are derived from those fundamentals, type inferences should generally be preferred over type declarations and assertions.
+
+There are several reasons for this:
+
+#### Advantages
+
+- Explicit type annotations (`:`) and type assertions (`as`, `!`) prevent inference-based narrowing of the user-supplied types.
+  - The compiler errs on the side of trusting user input, which prevents it from providing additional, and sometimes crucial, type information that it could otherwise infer.
+  <!-- TODO: Expand into entry. Add example. -->
+  - In TypeScript v4.9+ the `satisfies` operator can be used to assign type constraints that are narrowable through type inference.
+- Type inferences are responsive to changes in code without requiring user input, while annotations and assertions rely on hard-coding, making them brittle against code drift.
+- The `as const` operator can be used to further narrow an inferred abstract type into a specific literal type.
+
+🚫 Type declarations
+
+```ts
+const name: string = 'METAMASK'; // Type 'string'
+
+const BUILT_IN_NETWORKS = new Map<string, `0x${string}`>([
+  ['mainnet', '0x1'],
+  ['goerli', '0x5'],
+]); // Type 'Map<string, `0x${string}`>'
+```
+
+✅ Type inferences
+
+```ts
+const name = 'METAMASK'; // Type 'METAMASK'
+
+const BUILT_IN_NETWORKS = {
+  mainnet: '0x1',
+  goerli: '0x5',
+} as const; // Type { readonly mainnet: '0x1'; readonly goerli: '0x5'; }
+```
+
+### Type Narrowing
+
+There is a clear exception to the above: if an explicit type annotation or assertion can narrow an inferred type further, thereby improving its accuracy, it should be applied.
+
+##### Avoid widening a type with a type annotation
+
+> **Warning**<br />
+> Double-check that a declared type is narrower than the inferred type.<br />
+> Enforcing an even wider type defeats the purpose of adding an explicit type annotation, as it _loses_ type information instead of adding it.
+
+🚫
+
+```ts
+const chainId: string = this.messagingSystem(
+  'NetworkController:getProviderConfig',
+).chainId; // Type 'string'
+```
+
+✅
+
+```ts
+const chainId = this.messagingSystem(
+  'NetworkController:getProviderConfig',
+).chainId; // Type '`0x${string}`'
+```
+
+##### When instantiating an empty container type, provide a type annotation
+
+This is one case where type inference is unable to reach a useful conclusion without user-provided information. Since the compiler cannot arbitrarily restrict the range of types that could be inserted into the container, it has to assume the widest type, which is often `any`. It's up to the user to narrow that into the intended type with an explicit type annotation.
+
+🚫
+
+```ts
+const tokens = []; // Type 'any[]'
+const tokensMap = new Map(); // Type 'Map<any, any>'
+```
+
+✅
+
+```ts
+const tokens: string[] = []; // Type 'string[]'
+const tokensMap = new Map<string, Token>(); // Type 'Map<string, Token>'
+```
+
+##### Type guards and null checks can be used to improve type inference
+
+<!-- TODO: Add explanation and examples -->
+
+```ts
+function isSomeInterface(x: unknown): x is SomeInterface {
+  return (
+    'name' in x &&
+    typeof x.name === 'string' &&
+    'length' in x &&
+    typeof x.length === 'number'
+  );
+}
+
+function f(x: SomeInterface | SomeOtherInterface) {
+  if (isSomeInterface(x)) {
+    // Type of x: 'SomeInterface | SomeOtherInterface'
+    console.log(x.name); // Type of x: 'SomeInterface'. Type of x.name: 'string'.
+  }
+}`
+```
+
+### Type Assertions
+
+`as` assertions are unsafe. They overwrite type-checked and inferred types with user-supplied types that suppress compiler errors.
+
+#### Avoid `as`
+
+Type assertions make the code brittle against changes. While TypeScript will throw type errors against some unsafe or structurally unsound type assertions, it will generally accept the user-supplied type without type-checking. This can cause silent failures where errors are suppressed, even though the type's relationship to the rest of the code, or the type itself, has been altered so that the type assertion is no longer valid.
+
+#### Acceptable usages of `as`
+
+##### To prevent or fix `any` usage
+
+Unsafe as type assertions may be, they are still categorically preferable to using `any`.
+
+- With type assertions, we still get working intellisense, autocomplete, and other IDE features.
+- Type assertions also provide an indication of the expected type as intended by the author.
+- For type assertions to an incompatible shape, use `as unknown as` as a last resort rather than `any` or `as any`.
+
+##### To define user-defined type guards
+
+`as` syntax is often required to write type guards. See https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates.
+
+##### To type data objects whose shape and contents are determined at runtime
+
+Preferably, this typing should be accompanied by schema validation performed with type guards and unit tests.
+
+- e.g. The output of `JSON.parse()` or `await response.json()` for a known JSON input.
+- e.g. The type of a JSON file.
+
+<!-- TODO: Add example -->
+
+##### In tests, for mocking or to exclude irrelevant but required properties from an input object
+
+<!-- TODO: Add examples -->
+
+It's recommended to provide accurate typing if there's any chance that omitting properties affects the accuracy of the test.
+
+Otherwise, only mocking the properties needed in the test improves readability by making the intention and scope of the mocking clear, not to mention being convenient to write.
+
+### Compiler Directives
+
+<!-- TODO: Add section for `@ts-expect-error` -->
+
+#### Avoid `any`
+
+`any` is the most dangerous form of explicit type declaration, and should be completely avoided if possible.
+
+- `any` doesn't represent the widest type, or indeed any type at all. `any` is a compiler directive for _disabling_ static type checking for the value or type to which it's assigned.
+- `any` suppresses all error messages about its assignee. This includes errors that are changed or newly introduced by alterations to the code. This makes `any` the cause of dangerous **silent failures**, where the code fails at runtime but the compiler does not provide any prior warning.
+- `any` subsumes all other types it comes into contact with. Any type that is in a union, intersection, is a property of, or has any other relationship with an `any` type or value is erased and becomes an `any` type itself.
+
+<!-- TODO: Add examples -->
+
+```ts
+const handler:
+  | ((payload_0: ComposableControllerState, payload_1: Patch[]) => void)
+  | ((payload_0: any, payload_1: Patch[]) => void); // Type of 'payload_0': 'any'
+```
+
+- `any` pollutes all surrounding and downstream code.
+<!-- TODO: Add examples -->
+
+#### Fixes for `any`
+
+##### Try `unknown` instead
+
+`unknown` is the universal supertype i.e. the widest possible type.
+
+- When typing the assignee, `any` and `unknown` are interchangeable (every type is assignable to both).
+- However, when typing the assigned, `unknown` can't be used to replace `any`, as `unknown` is only assignable to `unknown`. In this case, try `never`, which is assignable to all types.
+<!-- TODO: Add example -->
+
+##### Don't allow generic types to use `any` as a default argument
+
+Some generic types use `any` as a default generic argument. This can silently introduce an `any` type into the code, causing unexpected behavior and suppressing useful errors.
+
+🚫
+
+```ts
+const NETWORKS = new Map({
+  mainnet: '0x1',
+  goerli: '0x5',
+}); // Type 'Map<any, any>'
+
+const mockGetNetworkConfigurationByNetworkClientId = jest.fn(); // Type 'jest.Mock<any, any>'
+mockGetNetworkConfigurationByNetworkClientId.mockImplementation(
+  (origin, type) => {},
+); // No error!
+// Even though 'mockImplementation' should only accept callbacks with a signature of '(networkClientId: string) => NetworkConfiguration | undefined'
+```
+
+✅
+
+```ts
+const NETWORKS = new Map<string, `0x${string}`>({
+  mainnet: '0x1',
+  goerli: '0x5',
+}); // Type 'Map<string, `0x${string}`>'
+
+const mockGetNetworkConfigurationByNetworkClientId = jest.fn<
+  ReturnType<NetworkController['getNetworkConfigurationByNetworkClientId']>,
+  Parameters<NetworkController['getNetworkConfigurationByNetworkClientId']>
+>(); // Type 'jest.Mock<NetworkConfiguration | undefined, [networkClientId: string]>'
+mockGetNetworkConfigurationByNetworkClientId.mockImplementation(
+  (origin, type) => {},
+);
+// Argument of type '(origin: any, type: any) => void' is not assignable to parameter of type '(networkClientId: string) => NetworkConfiguration | undefined'.
+// Target signature provides too few arguments. Expected 2 or more, but got 1.ts(2345)
+```
+
+#### Acceptable usages of `any`
+
+##### Assigning new properties to a generic type at runtime
+
+In most type errors involving property access or runtime property assignment, `any` usage can be avoided by substituting with `as unknown as`.
+
+🚫
+
+```ts
+for (const key of getKnownPropertyNames(this.internalConfig)) {
+  (this as any)[key] = this.internalConfig[key];
+}
+
+delete addressBook[chainId as any];
+// Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{ [chainId: `0x${string}`]: { [address: string]: AddressBookEntry; }; }'.
+//  No index signature with a parameter of type 'string' was found on type '{ [chainId: `0x${string}`]: { [address: string]: AddressBookEntry; }; }'.ts(7053)
+```
+
+✅
+
+```ts
+for (const key of getKnownPropertyNames(this.config)) {
+  (this as unknown as typeof this.config)[key] = this.config[key];
+}
+
+delete addressBook[chainId as unknown as `0x${string}`];
+```
+
+However, when assigning to a generic type, using `as any` is the only solution.
+
+🚫
+
+```ts
+(state as RateLimitState<RateLimitedApis>).requests[api][origin] = previous + 1;
+// is generic and can only be indexed for reading.ts(2862)
+```
+
+✅
+
+```ts
+(state as any).requests[api][origin] = previous + 1;
+```
+
+Even in this case, however, `any` usage might be avoidable by using `Object.assign` or spread operator syntax instead of assignment.
+
+```ts
+Object.assign(state, {
+  requests: {
+    ...state.requests,
+    [api]: { [origin] },
+  },
+});
+
+{
+  ...state,
+  requests: {
+    ...state.requests,
+    [api]: { [origin] },
+  },
+};
+```
+
+##### Within generic constraints
+
+✅
+
+```ts
+class BaseController<
+  ...,
+  messenger extends RestrictedControllerMessenger<N, any, any, string, string>
+> ...
+```
+
+- In general, using `any` in this context is not harmful in the same way that it is in other contexts, as the `any` types only are not directly assigned to any specific variable, and only function as constraints.
+- That said, more specific constraints provide better type safety and intellisense, and should be preferred wherever possible.
+
+##### Catching errors
+
+- `catch` only accepts `any` and `unknown` as the error type.
+- Recommended: Use `unknown` with type guards like `isJsonRpcError`.
+- Avoid typing an error object with `any` if it is passed on to be used elsewhere instead of just being thrown, as the `any` type will infect the downstream code.
+
+##### In tests, for mocking or to intentionally break features
+
+<!-- TODO: Add examples -->
+
+## Functions
+
+##### For functions and methods, provide explicit return types
 
 Although TypeScript is capable of inferring return types, adding them explicitly makes it much easier for the reader to see the API from the code alone and prevents unexpected changes to the API from emerging.
 
 🚫
 
-```javascript
+```ts
 async function removeAccount(address: Hex) {
   const keyring = await this.getKeyringForAccount(address);
 
@@ -25,7 +332,7 @@ async function removeAccount(address: Hex) {
 
 ✅
 
-```javascript
+```ts
 async function removeAccount(address: Hex): Promise<KeyringControllerState> {
   const keyring = await this.getKeyringForAccount(address);
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -669,15 +669,22 @@ To prevent `any` instances from being introduced into the codebase, it is not en
   🚫 A single type, `InferWithParams`, is set to `any` in `@metamask/utils`
 
   ```typescript
-  export declare type InferWithParams<Type extends Struct<any>, Params extends JsonRpcParams> = any;
-  
-  export declare type JsonRpcRequest<Params extends JsonRpcParams = JsonRpcParams> = InferWithParams<typeof JsonRpcRequestStruct, Params>; // Resolves to 'any'
-  
-  export declare type JsonRpcResponse<Result extends Json> = JsonRpcSuccess<Result> | JsonRpcFailure; // Resolves to 'any'
+  export declare type InferWithParams<
+    Type extends Struct<any>,
+    Params extends JsonRpcParams,
+  > = any;
+
+  export declare type JsonRpcRequest<
+    Params extends JsonRpcParams = JsonRpcParams,
+  > = InferWithParams<typeof JsonRpcRequestStruct, Params>; // Resolves to 'any'
+
+  export declare type JsonRpcResponse<Result extends Json> =
+    | JsonRpcSuccess<Result>
+    | JsonRpcFailure; // Resolves to 'any'
   ```
-  
+
   🚫 A downstream package is polluted with a large number of `any`s.
-  
+
   The valid error messages shown in the comments are suppressed by the `any` types.
 
   ```typescript
@@ -685,7 +692,7 @@ To prevent `any` instances from being introduced into the codebase, it is not en
     JsonRpcRequest,
     JsonRpcResponse
   } from '@metamask/utils'
-  
+
   function sendMetadataHandler<Params extends JsonRpcParams, Result extends Json>(
     req: JsonRpcRequest<Params> // any,
     res: JsonRpcResponse<Result> // any,
@@ -733,15 +740,15 @@ All of this makes `any` a prominent cause of dangerous **silent failures**, wher
 🚫 `any`
 
 ```typescript
-type ExampleFunction = () => any
-const exampleArray: any[] = ['a', 1, true]
+type ExampleFunction = () => any;
+const exampleArray: any[] = ['a', 1, true];
 ```
 
 ✅ `unknown`
 
 ```typescript
-type ExampleFunction = () => unknown
-const exampleArray: unknown[] = ['a', 1, true]
+type ExampleFunction = () => unknown;
+const exampleArray: unknown[] = ['a', 1, true];
 ```
 
 #### If `any` is being used as the _assigned_ type, try `never` first, and then widening to an appropriate subtype of the _assignee_ type
@@ -858,7 +865,7 @@ export class ComposableController<
   // (type parameter) ComposableControllerState in ComposableController<ComposableControllerState extends ComposableControllerStateConstraint>
   ComposableControllerState,
   ComposableControllerMessenger<ComposableControllerState>
-> 
+>
 ```
 
 - In general, using `any` in this context is not harmful in the same way that it is in other contexts, as the `any` types only are not directly assigned to any specific variable, and only function as constraints.

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -518,25 +518,33 @@ When a type assertion is used with a clear rationale, we should document the rea
 
 ### Escape Hatches
 
-TypeScript provides several escape hatches that disable compiler type checks altogether and suppress compiler errors. Using these to ignore typing issues is dangerous and reduces the effectiveness of TypeScript.
+TypeScript provides several escape hatches that disable compiler type checks altogether and suppress compiler errors. Using these to ignore typing issues is dangerous and reduces the effectiveness of TypeScript. The following are presented in order of preference for usage.
 
 - `@ts-expect-error`
   - Applies to a single line, which may contain multiple variables and errors.
   - **It alerts users if an error it was suppressing is resolved by changes in the code:**
+
     > **Error:** Unused '@ts-expect-error' directive.
+
+    This feature makes `@ts-expect-error` a safer alternative to type assertions by mitigating false positives.
+
   - `@ts-expect-error` usage should generally be reserved to situations where an error is the intended or expected result of an operation, not to silence errors when the correct typing solution is difficult to find.
+  - Allowed by the `@typescript-eslint/ban-ts-comment` rule, although a description comment is required.
 - `as any`
 
   - Applies only to a single instance of a single variable without propagating to other instances.
+  - Banned by the `@typescript-eslint/no-explicit-any` rule.
 
 - `@ts-ignore`
 
   - Applies to a line or block of code, which may contain multiple variables and errors.
   - Does not propagate to instances of the target variable or type that are outside of its scope.
+  - Banned by the `@typescript-eslint/ban-ts-comment` rule.
 
 - `any`:
   - Applies to all instances of the target variable or type throughout the entire codebase, and in downstream code as well.
   - Has the same effect as applying `@ts-ignore` to every single instance of the target variable or type.
+  - Banned by the `@typescript-eslint/no-explicit-any` rule.
 
 #### Use `@ts-expect-error` to force runtime execution of a branch for validation or testing
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -300,13 +300,11 @@ Although `as` is dangerous and discouraged from usage, the following is not an e
 
 ##### `as` is acceptable to use for preventing or fixing `any` usage
 
-Unsafe as type assertions may be, they should always be preferred to introducing `any` into the code.
+Type assertions are unsafe, but they are still always preferred to introducing `any` into the code.
 
 - With type assertions, we still get working intellisense, autocomplete, and other IDE and compiler features using the asserted type.
 - Type assertions also provide an indication of what the author intends or expects the type to be.
 - Often, the compiler will tell us exactly what the target type for an assertion needs to be, enabling us to avoid `as any`.
-- Even an assertion to a wrong type still allows the compiler to show us warnings and errors as the code changes, and is therefore preferrable to the dangerous radio silence enforced by `any`.
-- For type assertions to an incompatible shape, use `as unknown as` as a last resort rather than `any` or `as any`.
 
 ```typescript
 // Error: Argument of type '"getNftInformation"' is not assignable to parameter of type 'keyof NftController'.ts(2345)
@@ -325,6 +323,9 @@ sinon.stub(nftController, 'getNftInformation' as any);
 ```typescript
 sinon.stub(nftController, 'getNftInformation' as keyof typeof nftController);
 ```
+
+- Even an assertion to a wrong type still allows the compiler to show us warnings and errors as the code changes, and is therefore preferrable to the dangerous radio silence enforced by `any`.
+- For type assertions to an incompatible shape, use `as unknown as` as a last resort rather than `any` or `as any`.
 
 ##### `as` is acceptable to use for TypeScript syntax other than type assertion
 
@@ -414,7 +415,7 @@ Therefore, to prevent new `any` instances from being introduced into our codebas
 The key thing to remember about `any` is that it does not resolve errors, but only hides them. The errors still affect the code, but `any` makes it impossible to assess and counteract their influence.
 
 - `any` doesn't represent the widest type, or indeed any type at all. `any` is a compiler directive for _disabling_ static type checking for the value or type to which it's assigned.
-- `any` suppresses all error messages about its assignee. This makes code with `any` usage brittle against changes, since the compiler is unable to update its feedback even when the code has changed enough to alter, remove, or add new type errors.
+- `any` suppresses all error messages about its assignee. This makes code with `any` usage brittle against changes, since the compiler is unable to update its feedback even when the code has changed enough to alter or remove the error, or even add new type errors.
 - `any` subsumes all other types it comes into contact with. Any type that is in a union, intersection, is a property of, or has any other relationship with an `any` type or value becomes an `any` type itself. This represents an unmitigated loss of type information.
 
 ```typescript
@@ -430,27 +431,29 @@ function returnsAny(): any {
 const { a, b, c } = returnsAny();
 ```
 
-- `any` infects all surrounding and downstream code with its directive to suppress errors. This is the most dangerous characteristic of `any`, as it causes the encroachment of unsafe code, for which the TypeScript compiler can make no guarantees on type safety or runtime behavior.
+- `any` infects all surrounding and downstream code with its directive to suppress errors. This is the most dangerous characteristic of `any`, as it causes the encroachment of unsafe code with no guarantees about type safety or runtime behavior.
 
-All of this makes `any` a prominent cause of dangerous **silent failures**, where the code fails at runtime but the compiler does not provide any prior warning, which defeats the purpose of using a statically-typed language.
+All of this makes `any` a prominent cause of dangerous **silent failures** (false negatives), where the code fails at runtime but the compiler does not provide any prior warning, which defeats the purpose of using a statically-typed language.
 
-##### When `any` , try `unknown` and `never` instead
+##### When tempted to use `any`, try `unknown` and `never` instead
 
 ###### `unknown`
+
+`any` usage is often motivated by a need to find a placeholder type that could be anything. `unknown` is the most likely type-safe substitute for `any` in these cases.
 
 - `unknown` is the universal supertype i.e. the widest possible type, equivalent to the universal set(U).
 - Every type is assignable to `unknown`, but `unknown` is only assignable to `unknown`.
 - When typing the _assignee_, `any` and `unknown` are completely interchangeable since every type is assignable to both.
-- `any` usage is often motivated by a need to find a placeholder type that could be anything. `unknown` is the most likely type-safe substitute for `any` in these cases.
 
 ###### `never`
+
+`never` is worth trying as a starting point for narrowing down the type, as it is the universal subtype and assignable to all types.
 
 - `never` is the universal subtype i.e. the narrowest possible type, equivalent to the null set(∅).
 - `never` is assignable to every type, but the only type that is assignable to `never` is `never`.
 - When typing the _assigned_:
   - `unknown` is unable to replace `any`, as `unknown` is only assignable to `unknown`.
   - The type of the _assigned_ must be a subtype of the _assignee_.
-  - `never` is worth trying as a starting point, as it is the universal subtype and assignable to all types.
   - If the assigned type simultaneously needs to be the assignee for another type, `never` will not work, as no type is assignable to `never`.
 
 <!-- TODO: Add examples -->

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -222,13 +222,24 @@ const handler:
 
 #### Fixes for `any`
 
-##### Try `unknown` instead
+##### Try `unknown` and `never` instead
 
-`unknown` is the universal supertype i.e. the widest possible type.
+###### `unknown`
 
-- When typing the assignee, `any` and `unknown` are interchangeable (every type is assignable to both).
-- However, when typing the assigned, `unknown` can't be used to replace `any`, as `unknown` is only assignable to `unknown`. In this case, try `never`, which is assignable to all types.
-<!-- TODO: Add example -->
+- `unknown` is the universal supertype i.e. the widest possible type.
+- Every type is assignable to `unknown`, but `unknown` is only assignable to `unknown`.
+- When typing the _assignee_, `any` and `unknown` are completely interchangeable since every type is assignable to both.
+- `any` usage is often motivated by a need to find a placeholder type that could be anything. `unknown` is the most likely type-safe substitute for `any` in these cases.
+
+##### `never`
+
+- `never` is the universal subtype i.e. the narrowest possible type.
+- `never` is assignable to every type, but the only type that is assignable to `never` is `never`.
+- When typing the _assigned_:
+  - `unknown` is unable to replace `any`, as `unknown` is only assignable to `unknown`.
+  - The type of the _assigned_ must be a subtype of the _assignee_.
+  - `never` is worth trying, as it is the universal subtype and assignable to all types.
+  <!-- TODO: Add example -->
 
 ##### Don't allow generic types to use `any` as a default argument
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -6,11 +6,11 @@ These guidelines specifically apply to TypeScript.
 
 ### Type Inference
 
-TypeScript is very good at inferring types. A well-maintained codebase can provide strict type safety with explicit type annotations being the exception rather than the rule.
+TypeScript is very good at inferring types. It is capable of providing strict type safety while ensuring that explicit type annotations are the exception rather than the rule.
 
-When writing TypeScript, function and class signatures, and types that express the domain model of the codebase will require explicit definitions and annotations.
+Some fundamental type information must always be supplied by the user, such as function and class signatures, interfaces for interacting with external entities, and types that express the domain model of the codebase.
 
-However, for other types and values that are derived from those fundamentals, type inferences should generally be preferred over type declarations and assertions.
+However, for the remaining majority of types and values, **type inference should generally be preferred over type annotations and assertions**.
 
 There are several reasons for this:
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -296,6 +296,8 @@ nftMetadataResults.filter(
 
 #### Acceptable usages of `as`
 
+Although `as` is dangerous and discouraged from usage, the following is not an exhaustive list of its valid use cases.
+
 ##### `as` is acceptable to use for preventing or fixing `any` usage
 
 Unsafe as type assertions may be, they should always be preferred to introducing `any` into the code.
@@ -492,6 +494,8 @@ mockGetNetworkConfigurationByNetworkClientId.mockImplementation(
 ```
 
 #### Acceptable usages of `any`
+
+`any` is only acceptable for very specific usages. The following should be considered an exhaustive list of its valid use cases.
 
 ##### `any` may be necessary when assigning new properties to or deleting properties from a generic type at runtime
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -6,19 +6,17 @@ These guidelines specifically apply to TypeScript.
 
 ### Type Inference
 
-TypeScript is very good at inferring types. It is capable of providing strict type safety while ensuring that explicit type annotations are the exception rather than the rule.
+TypeScript is very good at inferring types. Explicit type annotations and assertions are the exception rather than the rule in a well-managed TypeScript codebase with strong type safety guarantees.
 
 Some fundamental type information must always be supplied by the user, such as function and class signatures, interfaces for interacting with external entities or data types, and types that express the domain model of the codebase.
 
 However, for the remaining majority of types and values, **type inference should generally be preferred over type annotations and assertions**.
 
-There are several reasons for this:
-
 ##### Type inference should be preferred over explicit annotations and assertions
 
-- Explicit type annotations (`:`) and type assertions (`as`, `!`) prevent inference-based narrowing of the user-supplied types.
-  - The compiler errs on the side of trusting user input, which prevents it from providing additional type information that it could infer.
-  - In TypeScript v4.9+, the `satisfies` operator can be used to assign type constraints that are narrowable through type inference.
+- Explicit type annotations (`:`) and type assertions (`as`, `!`) prevent further inference-based narrowing of the user-supplied types.
+  - The compiler errs on the side of trusting user input, which prevents it from providing additional type information that it is able to infer.
+  - To resolve this limitation, the `satisfies` operator was introduced in TypeScript v4.9, which can be used to assign type constraints that are narrowable through type inference.
     <!-- TODO: Add examples -->
 - Type inferences are responsive to changes in code without requiring user input, while annotations and assertions rely on hard-coding, making them brittle against code drift.
 - The `as const` operator can be used to narrow an inferred abstract type into a specific literal type.
@@ -261,7 +259,7 @@ sinon.stub(nftController, 'getNftInformation' as keyof typeof nftController)
 
 - Writing type guards often reqiures using the `as` keyword.
 
-```ts
+```typescript
 function isFish(pet: Fish | Bird): pet is Fish {
   return (pet as Fish).swim !== undefined;
 }
@@ -269,7 +267,7 @@ function isFish(pet: Fish | Bird): pet is Fish {
 
 - Key remapping in mapped types uses the `as` keyword.
 
-```ts
+```typescript
 type MappedTypeWithNewProperties<Type> = {
   [Properties in keyof Type as NewKeyType]: Type[Properties];
 };
@@ -290,7 +288,7 @@ Preferably, this typing should be accompanied by runtime schema validation perfo
 
 It's recommended to provide accurate typing if there's any chance that omitting properties affects the accuracy of the test.
 
-Otherwise, only mocking the properties needed in the test improves readability by making the intention and scope of the mocking clear, not to mention being convenient to write.
+If that is not the case, however, mocking only the properties needed in the test improves readability. It makes the intention and scope of the mock clear, and is much more convenient to write.
 
 ### Compiler Directives
 
@@ -303,7 +301,6 @@ Otherwise, only mocking the properties needed in the test improves readability b
 - `any` doesn't represent the widest type, or indeed any type at all. `any` is a compiler directive for _disabling_ static type checking for the value or type to which it's assigned.
 - `any` suppresses all error messages about its assignee. This includes errors that are changed or newly introduced by alterations to the code. This makes `any` the cause of dangerous **silent failures**, where the code fails at runtime but the compiler does not provide any prior warning.
 - `any` subsumes all other types it comes into contact with. Any type that is in a union, intersection, is a property of, or has any other relationship with an `any` type or value is erased and becomes an `any` type itself.
-  - This also means that `any` infects all surrounding and downstream code with its directive to suppress errors, expanding the surface area of code regarding which the TypeScript compiler can make no guarantees regarding type safety or runtime behavior.
 
 ```typescript
 // Type of 'payload_0': 'any'
@@ -458,7 +455,7 @@ class BaseController<
 
 ##### In tests, for mocking or to intentionally break features
 
-<!-- TODO: Add examples -->
+<!-- TODO: Add examples. Should be clear why type assertions couldn't be used instead -->
 
 ## Functions
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -383,22 +383,20 @@ TypeScript provides several escape hatches that disable compiler type checks alt
 
 - `@ts-expect-error`
   - Applies to a single line, which may contain multiple variables and errors.
-  - Is allowed by the ESLint rule `@typescript-eslint/ban-ts-comment`, but is required to be accompanied by an explanation comment.
-  - **It alerts users if an error it was suppressing has been resolved by changes in the code**:
+  - **It alerts users if an error it was suppressing is resolved by changes in the code:**
     > **Error:** Unused '@ts-expect-error' directive.
+  - `@ts-expect-error` usage should generally be reserved to situations where an error is the intended or expected result of an operation, not to silence errors when the correct typing solution is difficult to find.
 - `as any`
 
-  - Applies to a single instance of a single variable.
-  - Is banned by the ESLint rule `@typescript-eslint/no-explicit-any.
+  - Applies only to a single instance of a single variable without propagating to other instances.
 
 - `@ts-ignore`
 
   - Applies to a line or block of code, which may contain multiple variables and errors.
-  - Is banned by the ESLint rule `@typescript-eslint/ban-ts-comment`.
+  - Does not propagate to instances of the target variable or type that are outside of its scope.
 
 - `any`:
   - Applies to all instances of the target variable or type throughout the entire codebase, and in downstream code as well.
-  - Is banned by the ESLint rule `@typescript-eslint/no-explicit-any.
   - Has the same effect as applying `@ts-ignore` to every single instance of the target variable or type.
 
 #### Use `@ts-expect-error` to force runtime execution of a branch for validation or testing

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -465,6 +465,37 @@ sinon.stub(nftController, 'getNftInformation');
 sinon.stub(nftController, 'getNftInformation' as keyof typeof nftController);
 ```
 
+#### Use `as unknown as` to force a type assertion to an incompatible type, or to perform runtime property access, assignment, or deletion
+
+- `as unknown as` enables structurally unsound type assertions to incompatible types. This should be used as a last resort for a very good reason, and not as a convenient way to force types into incorrect shapes that will temporarily silence errors.
+
+- `as unknown as` can also resolve type errors arising from runtime property access, assignment, or deletion.
+
+**Example <a id="example-03d4fc8b-73a3-478a-a986-df89c9b80775"></a> ([🔗 permalink](#example-03d4fc8b-73a3-478a-a986-df89c9b80775)):**
+
+🚫 `any`
+
+```typescript
+for (const key of getKnownPropertyNames(this.internalConfig)) {
+  (this as any)[key] = this.internalConfig[key];
+}
+
+delete addressBook[chainId as any];
+// Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{ [chainId: `0x${string}`]: { [address: string]: AddressBookEntry; }; }'.
+//  No index signature with a parameter of type 'string' was found on type '{ [chainId: `0x${string}`]: { [address: string]: AddressBookEntry; }; }'.ts(7053)
+```
+
+✅ `as unknown as`
+
+```typescript
+for (const key of getKnownPropertyNames(this.internalConfig)) {
+  (this as unknown as typeof this.internalConfig)[key] =
+    this.internalConfig[key];
+}
+
+delete addressBook[chainId as unknown as `0x${string}`];
+```
+
 #### `as` is always acceptable to use in TypeScript syntax that does not involve type assertions
 
 - `as const` assertions.
@@ -715,35 +746,6 @@ mockGetNetworkConfigurationByNetworkClientId.mockImplementation(
 );
 // Argument of type '(origin: any, type: any) => void' is not assignable to parameter of type '(networkClientId: string) => NetworkConfiguration | undefined'.
 // Target signature provides too few arguments. Expected 2 or more, but got 1.ts(2345)
-```
-
-#### Prefer `as unknown as` over `as any`
-
-In most type errors involving property access or runtime property assignment, `any` usage can be avoided by substituting with `as unknown as`.
-
-**Example <a id="example-03d4fc8b-73a3-478a-a986-df89c9b80775"></a> ([🔗 permalink](#example-03d4fc8b-73a3-478a-a986-df89c9b80775)):**
-
-🚫
-
-```typescript
-for (const key of getKnownPropertyNames(this.internalConfig)) {
-  (this as any)[key] = this.internalConfig[key];
-}
-
-delete addressBook[chainId as any];
-// Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{ [chainId: `0x${string}`]: { [address: string]: AddressBookEntry; }; }'.
-//  No index signature with a parameter of type 'string' was found on type '{ [chainId: `0x${string}`]: { [address: string]: AddressBookEntry; }; }'.ts(7053)
-```
-
-✅
-
-```typescript
-for (const key of getKnownPropertyNames(this.internalConfig)) {
-  (this as unknown as typeof this.internalConfig)[key] =
-    this.internalConfig[key];
-}
-
-delete addressBook[chainId as unknown as `0x${string}`];
 ```
 
 #### `any` may be acceptable to use within generic constraints

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -563,11 +563,7 @@ mockGetNetworkConfigurationByNetworkClientId.mockImplementation(
 // Target signature provides too few arguments. Expected 2 or more, but got 1.ts(2345)
 ```
 
-#### Acceptable usages of `any`
-
-`any` is only acceptable for very specific usages. The following should be considered an exhaustive list of its valid use cases.
-
-##### `any` may be necessary when assigning new properties to or deleting properties from a generic type at runtime
+##### Prefer `as unknown as` over `as any`
 
 In most type errors involving property access or runtime property assignment, `any` usage can be avoided by substituting with `as unknown as`.
 
@@ -596,43 +592,7 @@ for (const key of getKnownPropertyNames(this.internalConfig)) {
 delete addressBook[chainId as unknown as `0x${string}`];
 ```
 
-However, when assigning to a generic type, using `as any` is the only solution.
-
-###### Example (c67854d8-9f1e-4345-9b63-4484a6e8681e)
-
-🚫
-
-> **Error:** Type 'RateLimitedRequests<RateLimitedApis>[keyof RateLimitedApis]' is generic and can only be indexed for reading.ts(2862)
-
-```typescript
-(state as RateLimitState<RateLimitedApis>).requests[api][origin] = previous + 1;
-```
-
-✅
-
-```typescript
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-(state as any).requests[api][origin] = previous + 1;
-```
-
-Even in this case, however, `any` usage might be avoidable by using `Object.assign` or spread operator syntax instead of assignment.
-
-```typescript
-Object.assign(state, {
-  requests: {
-    ...state.requests,
-    [api]: { [origin] },
-  },
-});
-
-{
-  ...state,
-  requests: {
-    ...state.requests,
-    [api]: { [origin] },
-  },
-};
-```
+#### Acceptable usages of `any`
 
 ##### `any` may be acceptable to use within generic constraints
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -351,13 +351,17 @@ If that is not the case, however, mocking only the properties needed in the test
 
 ### Compiler Directives
 
+`any` is the most dangerous form of explicit type declaration, and should be completely avoided.
+
+Unfortunately, `any` is also such a tempting escape hatch from the TypeScript type system that there's a strong incentive to use it whenever a nontrivial typing issue is encountered. Entire teams can easily be enticed into "unblocking" feature development by temporarily using `any` with the intention of fixing it later. This is a major source of tech debt, and its destructive influence on the type safety of a codebase cannot be understated.
+
+Therefore, to prevent new `any` instances from being introduced into our codebase, we cannot rely on the `@typescript-eslint/no-explicit-any` ESLint rule. It's also necessary for all contributors to understand exactly why `any` is dangerous, and how it can be avoided.
+
 <!-- TODO: Add section for `@ts-expect-error` -->
 
 #### Avoid `any`
 
-`any` is the most dangerous form of explicit type declaration, and should be completely avoided.
-
-The key thing to remember about `any` is that it does not resolve errors, but only hides them. The errors still affect the code, only now it's impossible to assess and counteract their influence.
+The key thing to remember about `any` is that it does not resolve errors, but only hides them. The errors still affect the code, but `any` makes it impossible to assess and counteract their influence.
 
 - `any` doesn't represent the widest type, or indeed any type at all. `any` is a compiler directive for _disabling_ static type checking for the value or type to which it's assigned.
 - `any` suppresses all error messages about its assignee. This makes code with `any` usage brittle against changes, since the compiler is unable to update its feedback even when the code has changed enough to alter, remove, or add new type errors.

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -220,27 +220,6 @@ const handler:
 - `any` pollutes all surrounding and downstream code.
 <!-- TODO: Add examples -->
 
-#### Fixes for `any`
-
-##### Try `unknown` and `never` instead
-
-###### `unknown`
-
-- `unknown` is the universal supertype i.e. the widest possible type.
-- Every type is assignable to `unknown`, but `unknown` is only assignable to `unknown`.
-- When typing the _assignee_, `any` and `unknown` are completely interchangeable since every type is assignable to both.
-- `any` usage is often motivated by a need to find a placeholder type that could be anything. `unknown` is the most likely type-safe substitute for `any` in these cases.
-
-##### `never`
-
-- `never` is the universal subtype i.e. the narrowest possible type.
-- `never` is assignable to every type, but the only type that is assignable to `never` is `never`.
-- When typing the _assigned_:
-  - `unknown` is unable to replace `any`, as `unknown` is only assignable to `unknown`.
-  - The type of the _assigned_ must be a subtype of the _assignee_.
-  - `never` is worth trying, as it is the universal subtype and assignable to all types.
-  <!-- TODO: Add example -->
-
 ##### Don't allow generic types to use `any` as a default argument
 
 Some generic types use `any` as a default generic argument. This can silently introduce an `any` type into the code, causing unexpected behavior and suppressing useful errors.
@@ -278,6 +257,29 @@ mockGetNetworkConfigurationByNetworkClientId.mockImplementation(
 // Argument of type '(origin: any, type: any) => void' is not assignable to parameter of type '(networkClientId: string) => NetworkConfiguration | undefined'.
 // Target signature provides too few arguments. Expected 2 or more, but got 1.ts(2345)
 ```
+
+#### Fixes for `any`
+
+##### Try `unknown` and `never` instead
+
+###### `unknown`
+
+- `unknown` is the universal supertype i.e. the widest possible type.
+- Every type is assignable to `unknown`, but `unknown` is only assignable to `unknown`.
+- When typing the _assignee_, `any` and `unknown` are completely interchangeable since every type is assignable to both.
+- `any` usage is often motivated by a need to find a placeholder type that could be anything. `unknown` is the most likely type-safe substitute for `any` in these cases.
+
+##### `never`
+
+- `never` is the universal subtype i.e. the narrowest possible type.
+- `never` is assignable to every type, but the only type that is assignable to `never` is `never`.
+- When typing the _assigned_:
+  - `unknown` is unable to replace `any`, as `unknown` is only assignable to `unknown`.
+  - The type of the _assigned_ must be a subtype of the _assignee_.
+  - `never` is worth trying, as it is the universal subtype and assignable to all types.
+
+  <!-- TODO: Add examples -->
+
 
 #### Acceptable usages of `any`
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -2,8 +2,6 @@
 
 ## Introduction
 
-These guidelines apply to TypeScript code in MetaMask repos.
-
 ### Purpose
 
 The _purpose_ of this document is to:

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -545,9 +545,9 @@ function f2(arg2: `0x${string}`) {
 }
 ```
 
-##### Don't allow `any` to be used as a generic default argument
+##### Don't allow generic type parameters to resolve to a default type of `any`
 
-Some generic types use `any` as a default generic argument. This can silently introduce an `any` type into the code, causing unexpected behavior and suppressing useful errors.
+Some generic types use `any` as a generic parameter default. If not consciously avoided, this can silently introduce an `any` type into the code, causing unexpected behavior and suppressing useful errors.
 
 ###### Example (c64ed0da-01f1-4b61-a28a-ff8e8ab3c8b5)
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -106,11 +106,9 @@ const BUILT_IN_NETWORKS = {
 
 ### Type Narrowing
 
-An explicit type annotation or assertion should be used if and only if they can further narrow an inferred type.
+An explicit type annotation or assertion should only be used if it can further narrow an inferred type.
 
 ##### Type guards and null checks can be used to improve type inference
-
-<!-- TODO: Add explanation and examples -->
 
 ```typescript
 function isSomeInterface(x: unknown): x is SomeInterface {
@@ -128,6 +126,48 @@ function f(x: SomeInterface | SomeOtherInterface) {
     console.log(x.name); // Type of x: 'SomeInterface'. Type of x.name: 'string'.
   }
 }`
+```
+
+```typescript
+const nftMetadataResults = await Promise.allSettled(...);
+
+nftMetadataResults
+  .filter((promise) => promise.status === 'fulfilled')
+  .forEach((elm) =>
+    this.updateNft(
+      elm.value.nft, // Property 'value' does not exist on type 'PromiseRejectedResult'.ts(2339)
+      ...
+    ),
+  );
+```
+
+🚫 Type assertion
+
+```typescript
+nftMetadataResults.filter(
+    (promise) => promise.status === 'fulfilled',
+  ) as { status: 'fulfilled'; value: NftUpdate }[])
+  .forEach((elm) =>
+    this.updateNft(
+      elm.value.nft,
+      ...
+    ),
+  );
+```
+
+✅ Use a type guard as the predicate for the filter operation, enabling TypeScript to narrow the filtered results to `PromiseFulfilledResult` at the type level
+
+```typescript
+nftMetadataResults.filter(
+    (result): result is PromiseFulfilledResult<NftUpdate> =>
+      result.status === 'fulfilled',
+  )
+  .forEach((elm) =>
+    this.updateNft(
+      elm.value.nft,
+      ...
+    ),
+  );
 ```
 
 ##### When instantiating an empty container type, provide a type annotation

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -41,7 +41,7 @@ However, for most types, inference should be preferred over annotations and asse
 
 Enforcing a wider type defeats the purpose of adding an explicit type declaration, as it _loses_ type information instead of adding it. Double-check that the declared type is narrower than the inferred type.
 
-##### **Example <a id="example-aba42b65-1cb9-4df0-881e-c2e0e79db0bd"></a> ([🔗 permalink](#example-aba42b65-1cb9-4df0-881e-c2e0e79db0bd)):**
+**Example <a id="example-aba42b65-1cb9-4df0-881e-c2e0e79db0bd"></a> ([🔗 permalink](#example-aba42b65-1cb9-4df0-881e-c2e0e79db0bd)):**
 
 🚫 Type declarations
 
@@ -73,7 +73,7 @@ const BUILT_IN_NETWORKS = {
 } as const; // Type { readonly mainnet: '0x1'; readonly sepolia: '0xaa36a7'; }
 ```
 
-##### **Example <a id="example-e9b0d703-032d-428b-a232-f5aa56a94470"></a> ([🔗 permalink](#example-e9b0d703-032d-428b-a232-f5aa56a94470)):**
+**Example <a id="example-e9b0d703-032d-428b-a232-f5aa56a94470"></a> ([🔗 permalink](#example-e9b0d703-032d-428b-a232-f5aa56a94470)):**
 
 ```typescript
 type TransactionMeta = TransactionBase &
@@ -135,7 +135,7 @@ Compared to type assertions, type annotations are more responsive to code drift.
 
 Introduced in [TypeScript 4.9](https://devblogs.microsoft.com/typescript/announcing-typescript-4-9/), the `satisfies` operator can be used to enforce a type constraint, while also allowing the compiler to fully narrow the assigned type through inference.
 
-##### **Example <a id="example-21ed5949-8d34-4754-b806-412de1696f46"></a> ([🔗 permalink](#example-21ed5949-8d34-4754-b806-412de1696f46)):**
+**Example <a id="example-21ed5949-8d34-4754-b806-412de1696f46"></a> ([🔗 permalink](#example-21ed5949-8d34-4754-b806-412de1696f46)):**
 
 🚫 Use a type annotation for type validation
 
@@ -167,7 +167,7 @@ The compiler doesn't have any values to use for inferring a type, and it cannot 
 
 It's up to the user to appropriately narrow down this type by adding an explicit annotation that provides information about the user's intentions.
 
-##### **Example <a id="example-b5a1175c-919f-4822-b92b-53a3d9dcd2e7"></a> ([🔗 permalink](#example-b5a1175c-919f-4822-b92b-53a3d9dcd2e7)):**
+**Example <a id="example-b5a1175c-919f-4822-b92b-53a3d9dcd2e7"></a> ([🔗 permalink](#example-b5a1175c-919f-4822-b92b-53a3d9dcd2e7)):**
 
 🚫
 
@@ -189,7 +189,7 @@ The reason type inference and the `satisfies` operator are generally preferred o
 
 When typing an extensible data type, however, this becomes a liability, because the narrowest type signature by definition doesn't include any newly assigned properties or elements. Therefore, when declaring or instantiating an object, array, or class, explicitly assign a type annotation, unless it is intended to be immutable.
 
-##### **Example <a id="example-a5fc6e57-2609-41c2-8315-558824bfffed"></a> ([🔗 permalink](#example-a5fc6e57-2609-41c2-8315-558824bfffed)):**
+**Example <a id="example-a5fc6e57-2609-41c2-8315-558824bfffed"></a> ([🔗 permalink](#example-a5fc6e57-2609-41c2-8315-558824bfffed)):**
 
 🚫 Type inference, `satisfies` operator
 
@@ -230,7 +230,7 @@ Type assertions are inherently unsafe and should only be used if the accurate ty
   - As changes accumulate in the codebase, type assertions may continue to enforce type assignments that have become incorrect, or keep silencing errors that have changed. This can cause dangerous silent failures (false negatives).
   - Type assertions will also provide no indication when they become unnecessary or redundant (false positives). Even if changes in the code resolve the error that the assertion was silencing, TypeScript will keep the assertion in place.
 
-    ##### **Example <a id="example-3675ab71-bcd6-4325-ac18-8ba4dd8ec03c"></a> ([🔗 permalink](#example-3675ab71-bcd6-4325-ac18-8ba4dd8ec03c)):**
+    **Example <a id="example-3675ab71-bcd6-4325-ac18-8ba4dd8ec03c"></a> ([🔗 permalink](#example-3675ab71-bcd6-4325-ac18-8ba4dd8ec03c)):**
 
     ```typescript
     enum Direction {
@@ -259,7 +259,7 @@ When a type assertion is used with a clear rationale, we should document the rea
 
 #### Avoid `as` assertions by using type guards to improve type inference
 
-##### **Example <a id="example-50c3fbc9-c2d7-4140-9f75-be5f0a56d541"></a> ([🔗 permalink](#example-50c3fbc9-c2d7-4140-9f75-be5f0a56d541)):**
+**Example <a id="example-50c3fbc9-c2d7-4140-9f75-be5f0a56d541"></a> ([🔗 permalink](#example-50c3fbc9-c2d7-4140-9f75-be5f0a56d541)):**
 
 ```typescript
 type SomeInterface = { name: string; length: number };
@@ -293,7 +293,7 @@ function f(x: SomeInterface | SomeOtherInterface) {
 }
 ```
 
-##### **Example <a id="example-f7ff4b0d-e5e9-4568-b916-5153ddd2095b"></a> ([🔗 permalink](#example-f7ff4b0d-e5e9-4568-b916-5153ddd2095b)):**
+**Example <a id="example-f7ff4b0d-e5e9-4568-b916-5153ddd2095b"></a> ([🔗 permalink](#example-f7ff4b0d-e5e9-4568-b916-5153ddd2095b)):**
 
 ```typescript
 const nftMetadataResults = await Promise.allSettled(...);
@@ -343,7 +343,7 @@ nftMetadataResults.filter(
 
 Often, the compiler will tell us exactly what the target type for an assertion needs to be.
 
-##### **Example <a id="example-2ee8f56a-e3be-417b-a2c0-260c1319b755"></a> ([🔗 permalink](#example-2ee8f56a-e3be-417b-a2c0-260c1319b755)):**
+**Example <a id="example-2ee8f56a-e3be-417b-a2c0-260c1319b755"></a> ([🔗 permalink](#example-2ee8f56a-e3be-417b-a2c0-260c1319b755)):**
 
 🚫 Compiler specifies that the target type should be `keyof NftController`
 
@@ -365,7 +365,7 @@ sinon.stub(nftController, 'getNftInformation' as keyof typeof nftController);
 
 - Key remapping in mapped types uses the `as` keyword.
 
-  ##### **Example <a id="example-6ffd8c99-4768-42e1-8cb7-5710d14f8552"></a> ([🔗 permalink](#example-6ffd8c99-4768-42e1-8cb7-5710d14f8552)):**
+  **Example <a id="example-6ffd8c99-4768-42e1-8cb7-5710d14f8552"></a> ([🔗 permalink](#example-6ffd8c99-4768-42e1-8cb7-5710d14f8552)):**
 
   ```typescript
   type MappedTypeWithNewProperties<Type> = {
@@ -401,7 +401,7 @@ Sometimes, there is a need to force a branch to execute at runtime for security 
 
 This is often the case when downstream consumers of the code are using JavaScript and do not have access to compile-time guardrails.
 
-##### **Example <a id="example-76b145a7-89bf-4f19-914b-d1c02e2db185"></a> ([🔗 permalink](#example-76b145a7-89bf-4f19-914b-d1c02e2db185)):**
+**Example <a id="example-76b145a7-89bf-4f19-914b-d1c02e2db185"></a> ([🔗 permalink](#example-76b145a7-89bf-4f19-914b-d1c02e2db185)):**
 
 🚫
 
@@ -445,7 +445,7 @@ exampleFunction('__proto__');
 
 #### `@ts-expect-error` may be acceptable to use in tests, to intentionally break features
 
-##### **Example <a id="example-e299e95d-1c41-4251-85b6-f8064b22f577"></a> ([🔗 permalink](#example-e299e95d-1c41-4251-85b6-f8064b22f577)):**
+**Example <a id="example-e299e95d-1c41-4251-85b6-f8064b22f577"></a> ([🔗 permalink](#example-e299e95d-1c41-4251-85b6-f8064b22f577)):**
 
 ✅
 
@@ -475,7 +475,7 @@ The key thing to remember about `any` is that it does not resolve errors, but on
 - `any` suppresses all error messages about its assignee. This makes code with `any` usage brittle against changes, since the compiler is unable to update its feedback even when the code has changed enough to alter or remove the error, or even add new type errors.
 - `any` subsumes all other types it comes into contact with. Any type that is in a union, intersection, is a property of, or has any other relationship with an `any` type or value becomes an `any` type itself. This represents an unmitigated loss of type information.
 
-  ##### **Example <a id="example-1fb5b0ad-61a9-4ad8-9d84-e29b78d88325"></a> ([🔗 permalink](#example-1fb5b0ad-61a9-4ad8-9d84-e29b78d88325)):**
+  **Example <a id="example-1fb5b0ad-61a9-4ad8-9d84-e29b78d88325"></a> ([🔗 permalink](#example-1fb5b0ad-61a9-4ad8-9d84-e29b78d88325)):**
 
   ```typescript
   // Type of 'payload_0': 'any'
@@ -523,7 +523,7 @@ However, `never` is assignable to all types
 
 > **Note:** Once `unknown` has been ruled out as a substitute for `any`, trying `never` serves as a valuable test: It tells us that the search space for the correct substitute type is bounded to subtypes of the _assignee_ type.
 
-##### **Example <a id="example-56165606-17db-479d-a2f7-cc95250f2129"></a> ([🔗 permalink](#example-56165606-17db-479d-a2f7-cc95250f2129)):**
+**Example <a id="example-56165606-17db-479d-a2f7-cc95250f2129"></a> ([🔗 permalink](#example-56165606-17db-479d-a2f7-cc95250f2129)):**
 
 ```typescript
 function f1(arg1: string) { ... }
@@ -571,7 +571,7 @@ function f2(arg2: `0x${string}`) {
 
 Some generic types use `any` as a generic parameter default. If not consciously avoided, this can silently introduce an `any` type into the code, causing unexpected behavior and suppressing useful errors.
 
-##### **Example <a id="example-c64ed0da-01f1-4b61-a28a-ff8e8ab3c8b5"></a> ([🔗 permalink](#example-c64ed0da-01f1-4b61-a28a-ff8e8ab3c8b5)):**
+**Example <a id="example-c64ed0da-01f1-4b61-a28a-ff8e8ab3c8b5"></a> ([🔗 permalink](#example-c64ed0da-01f1-4b61-a28a-ff8e8ab3c8b5)):**
 
 🚫
 
@@ -601,7 +601,7 @@ mockGetNetworkConfigurationByNetworkClientId.mockImplementation(
 
 In most type errors involving property access or runtime property assignment, `any` usage can be avoided by substituting with `as unknown as`.
 
-##### **Example <a id="example-03d4fc8b-73a3-478a-a986-df89c9b80775"></a> ([🔗 permalink](#example-03d4fc8b-73a3-478a-a986-df89c9b80775)):**
+**Example <a id="example-03d4fc8b-73a3-478a-a986-df89c9b80775"></a> ([🔗 permalink](#example-03d4fc8b-73a3-478a-a986-df89c9b80775)):**
 
 🚫
 
@@ -628,7 +628,7 @@ delete addressBook[chainId as unknown as `0x${string}`];
 
 #### `any` may be acceptable to use within generic constraints
 
-##### **Example <a id="example-706045b1-1f01-4e24-ae02-d9a3a8e81615"></a> ([🔗 permalink](#example-706045b1-1f01-4e24-ae02-d9a3a8e81615)):**
+**Example <a id="example-706045b1-1f01-4e24-ae02-d9a3a8e81615"></a> ([🔗 permalink](#example-706045b1-1f01-4e24-ae02-d9a3a8e81615)):**
 
 ✅
 
@@ -644,7 +644,7 @@ class BaseController<
 - More specific constraints provide better type safety and intellisense, and should be preferred wherever possible.
 - This only applies to generic _constraints_. It does not apply to passing in `any` as a generic _argument_.
 
-  ##### **Example <a id="example-7b9781b4-0f33-4619-ba50-a90b2594e23f"></a> ([🔗 permalink](#example-7b9781b4-0f33-4619-ba50-a90b2594e23f)):**
+  **Example <a id="example-7b9781b4-0f33-4619-ba50-a90b2594e23f"></a> ([🔗 permalink](#example-7b9781b4-0f33-4619-ba50-a90b2594e23f)):**
 
   🚫
 
@@ -659,7 +659,7 @@ class BaseController<
 
 Although TypeScript is capable of inferring return types, adding them explicitly makes it much easier for the reader to see the API from the code alone and prevents unexpected changes to the API from emerging.
 
-##### **Example <a id="example-a88b18ef-b066-4aa7-8106-bc244298f9e6"></a> ([🔗 permalink](#example-a88b18ef-b066-4aa7-8106-bc244298f9e6)):**
+**Example <a id="example-a88b18ef-b066-4aa7-8106-bc244298f9e6"></a> ([🔗 permalink](#example-a88b18ef-b066-4aa7-8106-bc244298f9e6)):**
 
 🚫
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -502,46 +502,70 @@ Type assertions are unsafe, but they are still always preferred over introducing
 - Type assertions also provide an indication of what the author intends or expects the type to be.
 - Even an assertion to a wrong type still allows the compiler to show us warnings and errors as the code changes.
 
+#### If `any` is being used as the _assignee_ type, try `unknown` first, and then try narrowing to an appropriate supertype of the _assigned_ type
 
-`any` usage is often motivated by a need to find a placeholder type that could be anything. `unknown` is the most likely type-safe substitute for `any` in these cases.
+`any` usage is often motivated by a need to find a placeholder type that could be anything. `unknown` is a likely type-safe substitute for `any` in these cases.
 
 - `unknown` is the universal supertype i.e. the widest possible type, equivalent to the universal set(U).
-- Every type is assignable to `unknown`, but `unknown` is only assignable to `unknown`.
+- Every type is assignable to `unknown`, but `unknown` is not assignable to any type but itself.
 - When typing the _assignee_, `any` and `unknown` are completely interchangeable since every type is assignable to both.
 
-##### If `any` is being used as the _assigned_ type, find an appropriate subtype of the _assignee_ type
+<!-- TODO: Add example -->
+
+#### If `any` is being used as the _assigned_ type, try `never` first, and then try widening to an appropriate subtype of the _assignee_ type
 
 Unfortunately, when typing the _assigned_ type, `unknown` cannot substitute `any` in most cases, because:
 
 - `unknown` is only assignable to `unknown`.
 - The type of the _assigned_ must be a subtype of the _assignee_, but `unknown` can only be a subtype of `unknown`.
 
+However, `never` is assignable to all types
+
+> **Note:** Once `unknown` has been ruled out as a substitute for `any`, trying `never` serves as a valuable test: It tells us that the search space for the correct substitute type is bounded to subtypes of the _assignee_ type.
+
 ##### **Example <a id="example-56165606-17db-479d-a2f7-cc95250f2129"></a> ([🔗 permalink](#example-56165606-17db-479d-a2f7-cc95250f2129)):**
 
-  ```typescript
-  function f1(arg1: string) { ... }
-  function f2(arg2: any) {
-    f1(arg2) // `arg1` is the assignee type, and `arg2` is the assigned type.
-  }
-  ```
+```typescript
+function f1(arg1: string) { ... }
+```
 
-  🚫 `unknown`
+🚫 `any`
 
-  ```typescript
-  function f1(arg1: string) { ... }
-  function f2(arg2: unknown) {
-    f1(arg2) // Error: Argument of type 'unknown' is not assignable to parameter of type 'string'.(2345)
-  }
-  ```
+In the function call `f1(arg2)`, the argument `arg2` is the _assigned_ type and the parameter `arg1` is the _assignee_ type.
 
-  ✅ Subtype of `string`, the assignee type
+```typescript
+function f2(arg2: any) {
+  f1(arg2);
+}
+```
 
-  ```typescript
-  function f1(arg1: string) { ... }
-  function f2(arg2: `0x${string}`) {
-    f1(arg2)
-  }
-  ```
+🚫 `unknown`
+
+> **Error:** Argument of type 'unknown' is not assignable to parameter of type 'string'.(2345)
+
+```typescript
+function f2(arg2: unknown) {
+  f1(arg2); // Error
+}
+```
+
+✅ `never`
+
+This works, but `arg2` can be widened further.
+
+```typescript
+function f2(arg2: never) {
+  f1(arg2); // No error
+}
+```
+
+✅ Subtype of `string`, the assignee type
+
+```typescript
+function f2(arg2: `0x${string}`) {
+  f1(arg2); // No error
+}
+```
 
 #### Don't allow generic type parameters to resolve to a default type of `any`
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -405,20 +405,39 @@ TypeScript provides several escape hatches that disable compiler type checks alt
   - Is banned by the ESLint rule `@typescript-eslint/no-explicit-any.
   - Has the same effect as applying `@ts-ignore` to every single instance of the target variable or type.
 
-#### Acceptable usages of `@ts-expect-error`
+#### Use `@ts-expect-error` to force runtime execution of a branch for validation or testing
 
-In general, `@ts-expect-error` usage should be reserved to situations where an error is the intended or expected result of an operation, not to silence errors when the correct typing solution couldn't be found.
+Sometimes, there is a need to force a branch to execute at runtime for security or testing purposes, even though that branch has correctly been inferred as being inaccessible by the TypeScript compiler.
 
-##### Use `@ts-expect-error` to force runtime execution of a branch for validation or testing
-
-Sometimes, there is a need to force a branch to execute at runtime for security or testing purposes, when that branch has correctly been inferred as being inaccessible by the TypeScript compiler.
+This is often the case when downstream consumers of the code are using JavaScript and do not have access to compile-time guardrails.
 
 ##### **Example <a id="example-76b145a7-89bf-4f19-914b-d1c02e2db185"></a> ([🔗 permalink](#example-76b145a7-89bf-4f19-914b-d1c02e2db185)):**
 
-> **Error:** This comparison appears to be unintentional because the types '`0x${string}`' and '"**proto**"' have no overlap.ts(2367)
+🚫
+
+> **Error:** This comparison appears to be unintentional because the types '`0x${string}`' and '"\_\_proto\_\_"' have no overlap.ts(2367)
 
 ```typescript
-exampleFunction(chainId: `0x${string}`) {
+function exampleFunction(chainId: `0x${string}`) {
+    if (chainId === '__proto__') {
+      return;
+    }
+    ...
+}
+```
+
+🚫
+
+> **Error:** Argument of type '"\_\_proto\_\_"' is not assignable to parameter of type '`0x${string}`'.ts(2345)
+
+```typescript
+exampleFunction('__proto__');
+```
+
+✅
+
+```typescript
+function exampleFunction(chainId: `0x${string}`) {
     // @ts-expect-error Suppressing to perform runtime check
     if (chainId === '__proto__') {
       return;
@@ -427,7 +446,14 @@ exampleFunction(chainId: `0x${string}`) {
 }
 ```
 
-##### `@ts-expect-error` may be acceptable to use in tests, to intentionally break features
+✅
+
+```typescript
+// @ts-expect-error Suppressing to perform runtime check
+exampleFunction('__proto__');
+```
+
+#### `@ts-expect-error` may be acceptable to use in tests, to intentionally break features
 
 ##### **Example <a id="example-e299e95d-1c41-4251-85b6-f8064b22f577"></a> ([🔗 permalink](#example-e299e95d-1c41-4251-85b6-f8064b22f577)):**
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -361,15 +361,53 @@ If that is not the case, however, mocking only the properties needed in the test
 
 ### Compiler Directives
 
-`any` is the most dangerous form of explicit type declaration, and should be completely avoided.
+TypeScript provides several directive comments that can be used to suppress TypeScript compiler errors. Using these to avoid resolving typing issues is dangeorus and reduces the effectiveness of TypeScript overall.
 
-Unfortunately, `any` is also such a tempting escape hatch from the TypeScript type system that there's a strong incentive to use it whenever a nontrivial typing issue is encountered. Entire teams can easily be enticed into "unblocking" feature development by temporarily using `any` with the intention of fixing it later. This is a major source of tech debt, and its destructive effect on the type safety of a codebase cannot be understated.
+The `@typescript-eslint/ban-ts-comment` rule is enabled by default in `@metamask/eslint-config-typescript`, banning `@ts-ignore`, `@ts-nocheck` usage and enforcing that `@ts-expect-error` instances include a description. Outside of rare exceptions like converting a file to TypeScript, this rule should never be disabled or overriden.
 
-Therefore, to prevent new `any` instances from being introduced into our codebase, we cannot rely only on the `@typescript-eslint/no-explicit-any` ESLint rule. It's also necessary for all contributors to understand exactly why `any` is dangerous, and how it can be avoided.
+#### Acceptable usages of `@ts-expect-error`
 
-<!-- TODO: Add section for `@ts-expect-error` -->
+##### Use `@ts-expect-error` to force runtime execution of a branch for validation or testing
+
+Sometimes, there is a need to force a branch to execute at runtime for security or testing purposes, when that branch has correctly been inferred as being inaccessible by the TypeScript compiler.
+
+Suppressing compiler errors to avoid typing issues is usually dangerous because it results in a loss of information and safety. However, consciously using `@ts-expect-error` to add runtime checks represents an improvement in these aspects, and therefore isn't discouraged.
+
+✅
+
+> **Error:** This comparison appears to be unintentional because the types '`0x${string}`' and '"__proto__"' have no overlap.ts(2367)
+
+```typescript
+exampleFunction(chainId: `0x${string}`) {
+    // @ts-expect-error Suppressing to perform runtime check
+    if (chainId === '__proto__') {
+      return;
+    }
+    ...
+}
+```
+
+##### `@ts-expect-error` may be acceptable to use in tests, to intentionally break features
+
+✅
+
+```typescript
+// @ts-expect-error Suppressing to test runtime error handling
+
+// @ts-expect-error Intentionally testing invalid state
+
+// @ts-expect-error We are intentionally passing bad input.
+```
+
+##### If accompanied by a TODO comment, `@ts-expect-error` is acceptable to use for marking errors that have clear plans of being resolved
 
 #### Avoid `any`
+
+`any` is the most dangerous form of explicit type declaration, and should be completely avoided.
+
+Unfortunately, `any` is also such a tempting escape hatch from the TypeScript type system that there's a strong incentive to use it whenever a nontrivial typing issue is encountered. Entire teams can easily be enticed into a pattern of "unblocking" feature development by introducing `any` with the intention of fixing it later. This is a major source of tech debt, and its destructive effect on the type safety of a codebase cannot be understated.
+
+Therefore, to prevent new `any` instances from being introduced into our codebase, it is not enough to rely on the `@typescript-eslint/no-explicit-any` ESLint rule. It's also necessary for all contributors to understand exactly why `any` is dangerous, and how it can be avoided.
 
 The key thing to remember about `any` is that it does not resolve errors, but only hides them. The errors still affect the code, but `any` makes it impossible to assess and counteract their influence.
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -229,7 +229,7 @@ SUPPORTED_CHAIN_IDS.includes(chainId) // No error
 
 ### Type Assertions
 
-`as` assertions are inherently unsafe. They overwrite type-checked and inferred types with user-supplied types that suppress compiler errors.
+`as` assertions are inherently unsafe. They overwrite type-checked and inferred types with user-supplied types, and suppress the resulting compiler errors.
 
 They should only be introduced into the code if the accurate type is unreachable through other means.
 
@@ -353,15 +353,16 @@ nftMetadataResults.filter(
 
 #### Acceptable usages of `as`
 
-Although `as` is dangerous and discouraged from being used, the following is not intended as an exhaustive list of its valid use cases.
-
-##### `as` is acceptable to use for preventing or fixing `any` usage
-
 Type assertions are unsafe, but they are still always preferred to introducing `any` into the code.
 
 - With type assertions, we still get working intellisense, autocomplete, and other IDE and compiler features using the asserted type.
 - Type assertions also provide an indication of what the author intends or expects the type to be.
-- Often, the compiler will tell us exactly what the target type for an assertion needs to be, enabling us to avoid `as any`.
+
+- Even an assertion to a wrong type still allows the compiler to show us warnings and errors as the code changes, and is therefore preferrable to the dangerous radio silence enforced by `any`.
+
+##### Prefer type assertions over `as any`
+
+Often, the compiler will tell us exactly what the target type for an assertion needs to be, enabling us to avoid `as any`.
 
 ###### Example (2ee8f56a-e3be-417b-a2c0-260c1319b755)
 
@@ -383,26 +384,11 @@ sinon.stub(nftController, 'getNftInformation' as any);
 sinon.stub(nftController, 'getNftInformation' as keyof typeof nftController);
 ```
 
-- Even an assertion to a wrong type still allows the compiler to show us warnings and errors as the code changes, and is therefore preferrable to the dangerous radio silence enforced by `any`.
-- For type assertions to an incompatible shape, use `as unknown as` as a last resort rather than `any` or `as any`.
-<!-- TODO: Add example -->
+##### `as` is acceptable to use for typing data objects whose structure and contents are determined at runtime
 
-##### `as` is acceptable to use for typing data objects whose shape and contents are determined at runtime, externally, or through deserialization
-
-Preferably, this typing should be accompanied by runtime schema validation performed with type guards and unit tests.
-
-- e.g. The output of `JSON.parse()` or `await response.json()` for a known JSON input.
-- e.g. The type of a JSON file.
+This typing should be accompanied by schema validation or deserialization performed with type guards and unit tests.
 
 <!-- TODO: Add example -->
-
-##### `as` may be acceptable to use in tests, for mocking or to exclude irrelevant but required properties from an input object
-
-It's recommended to provide accurate typing if there's any chance that omitting properties affects the accuracy of the test.
-
-If that is not the case, however, mocking only the properties needed in the test improves readability. It makes the intention and scope of the mock clear, and is more convenient to write, which can encourage test writing and improve test coverage.
-
-<!-- TODO: Add examples -->
 
 #### `as` is always acceptable to use in the context of TypeScript syntax that does not involve type assertions
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -221,45 +221,41 @@ SUPPORTED_CHAIN_IDS.includes(chainId) // No error
 
 ### Type Assertions
 
-`as` assertions are inherently unsafe. They overwrite type-checked and inferred types with user-supplied types, and suppress the resulting compiler errors.
+Type assertions are inherently unsafe and should only be used if the accurate type is unreachable through other means.
 
-They should only be introduced into the code if the accurate type is unreachable through other means.
+- Type assertions overwrite type-checked and compiler-inferred types with user-supplied types, and suppress the resulting compiler errors.
+- Because type assertions do not affect runtime code in any way, it is likely that types asserted at compile time will conflict with values at runtime.
+- Type assertions make the codebase brittle against changes.
 
-##### Document safe or necessary use of type assertions
+  - As changes accumulate in the codebase, type assertions may continue to enforce type assignments that have become incorrect, or keep silencing errors that have changed. This can cause dangerous silent failures (false negatives).
+  - Type assertions will also provide no indication when they become unnecessary or redundant (false positives). Even if changes in the code resolve the error that the assertion was silencing, TypeScript will keep the assertion in place.
 
-When a type assertion is absolutely necessary due to constraints or is even safe due to runtime checks, we should document the reasoning behind its usage in the form of a comment.
+    ##### **Example <a id="example-3675ab71-bcd6-4325-ac18-8ba4dd8ec03c"></a> ([🔗 permalink](#example-3675ab71-bcd6-4325-ac18-8ba4dd8ec03c)):**
+
+    ```typescript
+    enum Direction {
+      Up = 'up',
+      Down = 'down',
+      Left = 'left',
+      Right = 'right',
+    }
+    const directions = Object.values(Direction);
+
+    // Error: Element implicitly has an 'any' type because index expression is not of type 'number'.(7015)
+    // Only one of the two `as` assertions necessary to fix error, but neither are flagged as redundant.
+    for (const key of Object.keys(directions) as (keyof typeof directions)[]) {
+      const direction = directions[key as keyof typeof directions];
+    }
+    ```
+
+#### Document safe or necessary use of type assertions
+
+When a type assertion is used with a clear rationale, we should document the reasoning behind its usage in the form of a comment.
+
+- A type assertion may be necessary to satisfy constraints, or to align with a type that is defined by an external source of truth and is known to be accurate.
+- A type assertion may be determined to be safe if it's accompanied by runtime validations.
 
 <!-- TODO: Add example -->
-
-#### Avoid `as`
-
-Type assertions make the code brittle against changes.
-
-While TypeScript and ESLint will flag some unsafe, structurally unsound, or redundant type assertions, they will generally accept user-supplied types without further type-checking.
-
-This can cause silent failures or false negatives where errors are suppressed. This is especially damaging as the codebase accumulates changes over time. Type assertions may continue to silence errors, even though the type itself, or the type's relationship to the rest of the code may have been altered so that the asserted type is no longer valid.
-
-##### Redundant or unnecessary `as` assertions are not flagged for removal
-
-Type assertions can also cause false positives, because assertions are independent expressions, untied to the type errors they were intended to fix. Even if code drift fixes or removes a particular type error, the type assertions that were put in place to fix that error will provide no indication that they are no longer necessary and now should be removed.
-
-##### **Example <a id="example-3675ab71-bcd6-4325-ac18-8ba4dd8ec03c"></a> ([🔗 permalink](#example-3675ab71-bcd6-4325-ac18-8ba4dd8ec03c)):**
-
-```typescript
-enum Direction {
-  Up = 'up',
-  Down = 'down',
-  Left = 'left',
-  Right = 'right',
-}
-const directions = Object.values(Direction);
-
-// Error: Element implicitly has an 'any' type because index expression is not of type 'number'.(7015)
-// Only one of the two `as` assertions necessary to fix error, but neither are flagged as redundant.
-for (const key of Object.keys(directions) as (keyof typeof directions)[]) {
-  const direction = directions[key as keyof typeof directions];
-}
-```
 
 #### Avoid `as` assertions by using type guards to improve type inference
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -50,6 +50,8 @@ However, for most types, inference should be preferred over annotations and asse
 
 Enforcing a wider type defeats the purpose of adding an explicit type declaration, as it _loses_ type information instead of adding it. Double-check that the declared type is narrower than the inferred type.
 
+###### Example (aba42b65-1cb9-4df0-881e-c2e0e79db0bd)
+
 🚫 Type declarations
 
 ```typescript
@@ -79,6 +81,8 @@ const BUILT_IN_NETWORKS = {
   sepolia: '0xaa36a7',
 } as const; // Type { readonly mainnet: '0x1'; readonly sepolia: '0xaa36a7'; }
 ```
+
+###### Example (e9b0d703-032d-428b-a232-f5aa56a94470)
 
 ```typescript
 type TransactionMeta = TransactionBase &
@@ -136,6 +140,8 @@ An explicit type annotation is acceptable for overriding an inferred type if...
 
 TypeScript provides the `satisfies` operator for constraining or validating a type. It is able to both enforce a type constraint and further narrow the assigned type through inference.
 
+###### Example (21ed5949-8d34-4754-b806-412de1696f46)
+
 🚫 Use a type annotation for type validation
 
 ```typescript
@@ -171,6 +177,8 @@ When the compiler is in doubt, an annotation will nudge it towards relying on ty
 ##### When instantiating an empty container type, provide a type annotation
 
 This is one case where type inference is unable to reach a useful conclusion without user-provided information. Since the compiler cannot arbitrarily restrict the range of types that could be inserted into the container, it has to assume the widest type, which is often `any`. It's up to the user to narrow that into the intended type by adding an explicit annotation.
+
+###### Example (b5a1175c-919f-4822-b92b-53a3d9dcd2e7)
 
 🚫
 
@@ -210,6 +218,8 @@ This can cause silent failures or false negatives where errors are suppressed. T
 
 Type assertions can also cause false positives, because assertions are independent expressions, untied to the type errors they were intended to fix. Even if code drift fixes or removes a particular type error, the type assertions that were put in place to fix that error will provide no indication that they are no longer necessary and now should be removed.
 
+###### Example (3675ab71-bcd6-4325-ac18-8ba4dd8ec03c)
+
 ```typescript
 enum Direction {
   Up = 'up',
@@ -227,6 +237,8 @@ for (const key of Object.keys(directions) as (keyof typeof directions)[]) {
 ```
 
 ##### Type guards can be used to improve type inference and avoid type assertion
+
+###### Example (50c3fbc9-c2d7-4140-9f75-be5f0a56d541)
 
 ```typescript
 function isSomeInterface(x: unknown): x is SomeInterface {
@@ -247,7 +259,6 @@ function f(x: SomeInterface | SomeOtherInterface) {
     // We know that `x` is `SomeInterface` because `x` has a `name` but `SomeOtherInterface` does not
     console.log((x as SomeInterface).name);
   }
-
 }
 ```
 
@@ -260,6 +271,8 @@ function f(x: SomeInterface | SomeOtherInterface) {
   }
 }
 ```
+
+###### Example (f7ff4b0d-e5e9-4568-b916-5153ddd2095b)
 
 ```typescript
 const nftMetadataResults = await Promise.allSettled(...);
@@ -315,6 +328,8 @@ Type assertions are unsafe, but they are still always preferred to introducing `
 - Type assertions also provide an indication of what the author intends or expects the type to be.
 - Often, the compiler will tell us exactly what the target type for an assertion needs to be, enabling us to avoid `as any`.
 
+###### Example (2ee8f56a-e3be-417b-a2c0-260c1319b755)
+
 ```typescript
 // Error: Argument of type '"getNftInformation"' is not assignable to parameter of type 'keyof NftController'.ts(2345)
 // 'getNftInformation' is a private method of class 'NftController'
@@ -340,6 +355,8 @@ sinon.stub(nftController, 'getNftInformation' as keyof typeof nftController);
 
 - Writing type guards often requires using the `as` keyword.
 
+###### Example (f16df571-266e-4030-b002-49554558ccd7)
+
 ```typescript
 function isFish(pet: Fish | Bird): pet is Fish {
   return (pet as Fish).swim !== undefined;
@@ -347,6 +364,8 @@ function isFish(pet: Fish | Bird): pet is Fish {
 ```
 
 - Key remapping in mapped types uses the `as` keyword.
+
+###### Example (6ffd8c99-4768-42e1-8cb7-5710d14f8552)
 
 ```typescript
 type MappedTypeWithNewProperties<Type> = {
@@ -381,10 +400,11 @@ TypeScript provides several directive comments that can be used to suppress Type
 
 Sometimes, there is a need to force a branch to execute at runtime for security or testing purposes, when that branch has correctly been inferred as being inaccessible by the TypeScript compiler.
 
+###### Example (76b145a7-89bf-4f19-914b-d1c02e2db185)
 
 ✅
 
-> **Error:** This comparison appears to be unintentional because the types '`0x${string}`' and '"__proto__"' have no overlap.ts(2367)
+> **Error:** This comparison appears to be unintentional because the types '`0x${string}`' and '"**proto**"' have no overlap.ts(2367)
 
 ```typescript
 exampleFunction(chainId: `0x${string}`) {
@@ -397,6 +417,8 @@ exampleFunction(chainId: `0x${string}`) {
 ```
 
 ##### `@ts-expect-error` may be acceptable to use in tests, to intentionally break features
+
+###### Example (e299e95d-1c41-4251-85b6-f8064b22f577)
 
 ✅
 
@@ -425,6 +447,8 @@ The key thing to remember about `any` is that it does not resolve errors, but on
 - `any` doesn't represent the widest type, or indeed any type at all. `any` is a compiler directive for _disabling_ static type checking for the value or type to which it's assigned.
 - `any` suppresses all error messages about its assignee. This makes code with `any` usage brittle against changes, since the compiler is unable to update its feedback even when the code has changed enough to alter or remove the error, or even add new type errors.
 - `any` subsumes all other types it comes into contact with. Any type that is in a union, intersection, is a property of, or has any other relationship with an `any` type or value becomes an `any` type itself. This represents an unmitigated loss of type information.
+
+###### Example (1fb5b0ad-61a9-4ad8-9d84-e29b78d88325)
 
 ```typescript
 // Type of 'payload_0': 'any'
@@ -470,6 +494,8 @@ All of this makes `any` a prominent cause of dangerous **silent failures** (fals
 
 Some generic types use `any` as a default generic argument. This can silently introduce an `any` type into the code, causing unexpected behavior and suppressing useful errors.
 
+###### Example (c64ed0da-01f1-4b61-a28a-ff8e8ab3c8b5)
+
 🚫
 
 ```typescript
@@ -512,6 +538,8 @@ mockGetNetworkConfigurationByNetworkClientId.mockImplementation(
 
 In most type errors involving property access or runtime property assignment, `any` usage can be avoided by substituting with `as unknown as`.
 
+###### Example (03d4fc8b-73a3-478a-a986-df89c9b80775)
+
 🚫
 
 ```typescript
@@ -537,16 +565,20 @@ delete addressBook[chainId as unknown as `0x${string}`];
 
 However, when assigning to a generic type, using `as any` is the only solution.
 
+###### Example (c67854d8-9f1e-4345-9b63-4484a6e8681e)
+
 🚫
+
+> **Error:** Type 'RateLimitedRequests<RateLimitedApis>[keyof RateLimitedApis]' is generic and can only be indexed for reading.ts(2862)
 
 ```typescript
 (state as RateLimitState<RateLimitedApis>).requests[api][origin] = previous + 1;
-// is generic and can only be indexed for reading.ts(2862)
 ```
 
 ✅
 
 ```typescript
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 (state as any).requests[api][origin] = previous + 1;
 ```
 
@@ -571,11 +603,14 @@ Object.assign(state, {
 
 ##### `any` may be acceptable to use within generic constraints
 
+###### Example (706045b1-1f01-4e24-ae02-d9a3a8e81615)
+
 ✅
 
 ```typescript
 class BaseController<
   ...,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   messenger extends RestrictedControllerMessenger<N, any, any, string, string>
 > ...
 ```
@@ -583,12 +618,13 @@ class BaseController<
 - In general, using `any` in this context is not harmful in the same way that it is in other contexts, as the `any` types only are not directly assigned to any specific variable, and only function as constraints.
 - That said, more specific constraints provide better type safety and intellisense, and should be preferred wherever possible.
 
-
 ## Functions
 
 ##### For functions and methods, provide explicit return types
 
 Although TypeScript is capable of inferring return types, adding them explicitly makes it much easier for the reader to see the API from the code alone and prevents unexpected changes to the API from emerging.
+
+###### Example (a88b18ef-b066-4aa7-8106-bc244298f9e6)
 
 🚫
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -49,7 +49,7 @@ However, for most types, inference should be preferred over annotations and asse
 
 Enforcing a wider type defeats the purpose of adding an explicit type declaration, as it _loses_ type information instead of adding it. Double-check that the declared type is narrower than the inferred type.
 
-###### Example (aba42b65-1cb9-4df0-881e-c2e0e79db0bd)
+**Example <a id="example-aba42b65-1cb9-4df0-881e-c2e0e79db0bd"></a> ([🔗 permalink](#example-aba42b65-1cb9-4df0-881e-c2e0e79db0bd))**:
 
 🚫 Type declarations
 
@@ -81,7 +81,7 @@ const BUILT_IN_NETWORKS = {
 } as const; // Type { readonly mainnet: '0x1'; readonly sepolia: '0xaa36a7'; }
 ```
 
-###### Example (e9b0d703-032d-428b-a232-f5aa56a94470)
+**Example <a id="example-e9b0d703-032d-428b-a232-f5aa56a94470"></a> ([🔗 permalink](#example-e9b0d703-032d-428b-a232-f5aa56a94470))**:
 
 ```typescript
 type TransactionMeta = TransactionBase &
@@ -143,7 +143,7 @@ Compared to type assertions, type annotations are more responsive to code drift.
 
 Introduced in [TypeScript 4.9](https://devblogs.microsoft.com/typescript/announcing-typescript-4-9/), the `satisfies` operator can be used to enforce a type constraint, while also allowing the compiler to fully narrow the assigned type through inference.
 
-###### Example (21ed5949-8d34-4754-b806-412de1696f46)
+**Example <a id="example-21ed5949-8d34-4754-b806-412de1696f46"></a> ([🔗 permalink](#example-21ed5949-8d34-4754-b806-412de1696f46))**:
 
 🚫 Use a type annotation for type validation
 
@@ -175,7 +175,7 @@ The compiler doesn't have any values to use for inferring a type, and it cannot 
 
 It's up to the user to appropriately narrow down this type by adding an explicit annotation that provides information about the user's intentions.
 
-###### Example (b5a1175c-919f-4822-b92b-53a3d9dcd2e7)
+**Example <a id="example-b5a1175c-919f-4822-b92b-53a3d9dcd2e7"></a> ([🔗 permalink](#example-b5a1175c-919f-4822-b92b-53a3d9dcd2e7))**:
 
 🚫
 
@@ -197,7 +197,7 @@ The reason type inference and the `satisfies` operator are generally preferred o
 
 When typing an extensible data type, however, this becomes a liability, because the narrowest type signature by definition doesn't include any newly assigned properties or elements. Therefore, when declaring or instantiating an object, array, or class, explicitly assign a type annotation, unless it is intended to be immutable.
 
-###### Example (a5fc6e57-2609-41c2-8315-558824bfffed)
+**Example <a id="example-a5fc6e57-2609-41c2-8315-558824bfffed"></a> ([🔗 permalink](#example-a5fc6e57-2609-41c2-8315-558824bfffed))**:
 
 🚫 Type inference, `satisfies` operator
 
@@ -251,7 +251,7 @@ This can cause silent failures or false negatives where errors are suppressed. T
 
 Type assertions can also cause false positives, because assertions are independent expressions, untied to the type errors they were intended to fix. Even if code drift fixes or removes a particular type error, the type assertions that were put in place to fix that error will provide no indication that they are no longer necessary and now should be removed.
 
-###### Example (3675ab71-bcd6-4325-ac18-8ba4dd8ec03c)
+**Example <a id="example-3675ab71-bcd6-4325-ac18-8ba4dd8ec03c"></a> ([🔗 permalink](#example-3675ab71-bcd6-4325-ac18-8ba4dd8ec03c))**:
 
 ```typescript
 enum Direction {
@@ -271,7 +271,7 @@ for (const key of Object.keys(directions) as (keyof typeof directions)[]) {
 
 ##### Type guards can be used to improve type inference and avoid type assertion
 
-###### Example (50c3fbc9-c2d7-4140-9f75-be5f0a56d541)
+**Example <a id="example-50c3fbc9-c2d7-4140-9f75-be5f0a56d541"></a> ([🔗 permalink](#example-50c3fbc9-c2d7-4140-9f75-be5f0a56d541))**:
 
 ```typescript
 function isSomeInterface(x: unknown): x is SomeInterface {
@@ -305,7 +305,7 @@ function f(x: SomeInterface | SomeOtherInterface) {
 }
 ```
 
-###### Example (f7ff4b0d-e5e9-4568-b916-5153ddd2095b)
+**Example <a id="example-f7ff4b0d-e5e9-4568-b916-5153ddd2095b"></a> ([🔗 permalink](#example-f7ff4b0d-e5e9-4568-b916-5153ddd2095b))**:
 
 ```typescript
 const nftMetadataResults = await Promise.allSettled(...);
@@ -364,7 +364,7 @@ Type assertions are unsafe, but they are still always preferred to introducing `
 
 Often, the compiler will tell us exactly what the target type for an assertion needs to be, enabling us to avoid `as any`.
 
-###### Example (2ee8f56a-e3be-417b-a2c0-260c1319b755)
+**Example <a id="example-2ee8f56a-e3be-417b-a2c0-260c1319b755"></a> ([🔗 permalink](#example-2ee8f56a-e3be-417b-a2c0-260c1319b755))**:
 
 ```typescript
 // Error: Argument of type '"getNftInformation"' is not assignable to parameter of type 'keyof NftController'.ts(2345)
@@ -396,13 +396,13 @@ This typing should be accompanied by schema validation or deserialization perfor
 
 - Key remapping in mapped types uses the `as` keyword.
 
-###### Example (6ffd8c99-4768-42e1-8cb7-5710d14f8552)
+  **Example <a id="example-6ffd8c99-4768-42e1-8cb7-5710d14f8552"></a> ([🔗 permalink](#example-6ffd8c99-4768-42e1-8cb7-5710d14f8552))**:
 
-```typescript
-type MappedTypeWithNewProperties<Type> = {
-  [Properties in keyof Type as NewKeyType]: Type[Properties];
-};
-```
+  ```typescript
+  type MappedTypeWithNewProperties<Type> = {
+    [Properties in keyof Type as NewKeyType]: Type[Properties];
+  };
+  ```
 
 ### Escape Hatches
 
@@ -436,7 +436,7 @@ In general, `@ts-expect-error` usage should be reserved to situations where an e
 
 Sometimes, there is a need to force a branch to execute at runtime for security or testing purposes, when that branch has correctly been inferred as being inaccessible by the TypeScript compiler.
 
-###### Example (76b145a7-89bf-4f19-914b-d1c02e2db185)
+**Example <a id="example-76b145a7-89bf-4f19-914b-d1c02e2db185"></a> ([🔗 permalink](#example-76b145a7-89bf-4f19-914b-d1c02e2db185))**:
 
 ✅
 
@@ -454,7 +454,7 @@ exampleFunction(chainId: `0x${string}`) {
 
 ##### `@ts-expect-error` may be acceptable to use in tests, to intentionally break features
 
-###### Example (e299e95d-1c41-4251-85b6-f8064b22f577)
+**Example <a id="example-e299e95d-1c41-4251-85b6-f8064b22f577"></a> ([🔗 permalink](#example-e299e95d-1c41-4251-85b6-f8064b22f577))**:
 
 ✅
 
@@ -484,20 +484,20 @@ The key thing to remember about `any` is that it does not resolve errors, but on
 - `any` suppresses all error messages about its assignee. This makes code with `any` usage brittle against changes, since the compiler is unable to update its feedback even when the code has changed enough to alter or remove the error, or even add new type errors.
 - `any` subsumes all other types it comes into contact with. Any type that is in a union, intersection, is a property of, or has any other relationship with an `any` type or value becomes an `any` type itself. This represents an unmitigated loss of type information.
 
-###### Example (1fb5b0ad-61a9-4ad8-9d84-e29b78d88325)
+  **Example <a id="example-1fb5b0ad-61a9-4ad8-9d84-e29b78d88325"></a> ([🔗 permalink](#example-1fb5b0ad-61a9-4ad8-9d84-e29b78d88325))**:
 
-```typescript
-// Type of 'payload_0': 'any'
-const handler:
-  | ((payload_0: ComposableControllerState, payload_1: Patch[]) => void)
-  | ((payload_0: any, payload_1: Patch[]) => void);
+  ```typescript
+  // Type of 'payload_0': 'any'
+  const handler:
+    | ((payload_0: ComposableControllerState, payload_1: Patch[]) => void)
+    | ((payload_0: any, payload_1: Patch[]) => void);
 
-function returnsAny(): any {
-  return { a: 1, b: true, c: 'c' };
-}
-// Types of a, b, c are all `any`
-const { a, b, c } = returnsAny();
-```
+  function returnsAny(): any {
+    return { a: 1, b: true, c: 'c' };
+  }
+  // Types of a, b, c are all `any`
+  const { a, b, c } = returnsAny();
+  ```
 
 - `any` infects all surrounding and downstream code with its directive to suppress errors. This is the most dangerous characteristic of `any`, as it causes the encroachment of unsafe code with no guarantees about type safety or runtime behavior.
 
@@ -518,38 +518,38 @@ Unfortunately, when typing the _assigned_ type, `unknown` cannot substitute `any
 - `unknown` is only assignable to `unknown`.
 - The type of the _assigned_ must be a subtype of the _assignee_, but `unknown` can only be a subtype of `unknown`.
 
-###### Example (56165606-17db-479d-a2f7-cc95250f2129)
+  **Example <a id="example-56165606-17db-479d-a2f7-cc95250f2129"></a> ([🔗 permalink](#example-56165606-17db-479d-a2f7-cc95250f2129))**:
 
-```typescript
-function f1(arg1: string) { ... }
-function f2(arg2: any) {
-  f1(arg2) // `arg1` is the assignee type, and `arg2` is the assigned type.
-}
-```
+  ```typescript
+  function f1(arg1: string) { ... }
+  function f2(arg2: any) {
+    f1(arg2) // `arg1` is the assignee type, and `arg2` is the assigned type.
+  }
+  ```
 
-🚫 `unknown`
+  🚫 `unknown`
 
-```typescript
-function f1(arg1: string) { ... }
-function f2(arg2: unknown) {
-  f1(arg2) // Error: Argument of type 'unknown' is not assignable to parameter of type 'string'.(2345)
-}
-```
+  ```typescript
+  function f1(arg1: string) { ... }
+  function f2(arg2: unknown) {
+    f1(arg2) // Error: Argument of type 'unknown' is not assignable to parameter of type 'string'.(2345)
+  }
+  ```
 
-✅ Subtype of `string`, the assignee type
+  ✅ Subtype of `string`, the assignee type
 
-```typescript
-function f1(arg1: string) { ... }
-function f2(arg2: `0x${string}`) {
-  f1(arg2)
-}
-```
+  ```typescript
+  function f1(arg1: string) { ... }
+  function f2(arg2: `0x${string}`) {
+    f1(arg2)
+  }
+  ```
 
 ##### Don't allow generic type parameters to resolve to a default type of `any`
 
 Some generic types use `any` as a generic parameter default. If not consciously avoided, this can silently introduce an `any` type into the code, causing unexpected behavior and suppressing useful errors.
 
-###### Example (c64ed0da-01f1-4b61-a28a-ff8e8ab3c8b5)
+**Example <a id="example-c64ed0da-01f1-4b61-a28a-ff8e8ab3c8b5"></a> ([🔗 permalink](#example-c64ed0da-01f1-4b61-a28a-ff8e8ab3c8b5))**:
 
 🚫
 
@@ -579,7 +579,7 @@ mockGetNetworkConfigurationByNetworkClientId.mockImplementation(
 
 In most type errors involving property access or runtime property assignment, `any` usage can be avoided by substituting with `as unknown as`.
 
-###### Example (03d4fc8b-73a3-478a-a986-df89c9b80775)
+**Example <a id="example-03d4fc8b-73a3-478a-a986-df89c9b80775"></a> ([🔗 permalink](#example-03d4fc8b-73a3-478a-a986-df89c9b80775))**:
 
 🚫
 
@@ -608,7 +608,7 @@ delete addressBook[chainId as unknown as `0x${string}`];
 
 ##### `any` may be acceptable to use within generic constraints
 
-###### Example (706045b1-1f01-4e24-ae02-d9a3a8e81615)
+**Example <a id="example-706045b1-1f01-4e24-ae02-d9a3a8e81615"></a> ([🔗 permalink](#example-706045b1-1f01-4e24-ae02-d9a3a8e81615))**:
 
 ✅
 
@@ -624,14 +624,14 @@ class BaseController<
 - More specific constraints provide better type safety and intellisense, and should be preferred wherever possible.
 - This only applies to generic _constraints_. It does not apply to passing in `any` as a generic _argument_.
 
-###### Example (7b9781b4-0f33-4619-ba50-a90b2594e23f)
+  **Example <a id="example-7b9781b4-0f33-4619-ba50-a90b2594e23f"></a> ([🔗 permalink](#example-7b9781b4-0f33-4619-ba50-a90b2594e23f))**:
 
-🚫
+  🚫
 
-```typescript
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const controllerMessenger = ControllerMessenger<any, any>;
-```
+  ```typescript
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const controllerMessenger = ControllerMessenger<any, any>;
+  ```
 
 ## Functions
 
@@ -639,7 +639,7 @@ const controllerMessenger = ControllerMessenger<any, any>;
 
 Although TypeScript is capable of inferring return types, adding them explicitly makes it much easier for the reader to see the API from the code alone and prevents unexpected changes to the API from emerging.
 
-###### Example (a88b18ef-b066-4aa7-8106-bc244298f9e6)
+**Example <a id="example-a88b18ef-b066-4aa7-8106-bc244298f9e6"></a> ([🔗 permalink](#example-a88b18ef-b066-4aa7-8106-bc244298f9e6))**:
 
 🚫
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -771,7 +771,7 @@ mockGetNetworkConfigurationByNetworkClientId.mockImplementation(
 
 **Example <a id="example-706045b1-1f01-4e24-ae02-d9a3a8e81615"></a> ([🔗 permalink](#example-706045b1-1f01-4e24-ae02-d9a3a8e81615)):**
 
-✅
+✅ `messenger` is not polluted by `any`
 
 ```typescript
 class BaseController<
@@ -779,6 +779,20 @@ class BaseController<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   messenger extends RestrictedControllerMessenger<N, any, any, string, string>
 > ...
+```
+
+✅ `ComposableControllerState` is not polluted by `any`
+
+```typescript
+export class ComposableController<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ComposableControllerState extends { [name: string]: Record<string, any> },
+> extends BaseController<
+  typeof controllerName,
+  // (type parameter) ComposableControllerState in ComposableController<ComposableControllerState extends ComposableControllerStateConstraint>
+  ComposableControllerState,
+  ComposableControllerMessenger<ComposableControllerState>
+> 
 ```
 
 - In general, using `any` in this context is not harmful in the same way that it is in other contexts, as the `any` types only are not directly assigned to any specific variable, and only function as constraints.

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -303,6 +303,7 @@ Otherwise, only mocking the properties needed in the test improves readability b
 - `any` doesn't represent the widest type, or indeed any type at all. `any` is a compiler directive for _disabling_ static type checking for the value or type to which it's assigned.
 - `any` suppresses all error messages about its assignee. This includes errors that are changed or newly introduced by alterations to the code. This makes `any` the cause of dangerous **silent failures**, where the code fails at runtime but the compiler does not provide any prior warning.
 - `any` subsumes all other types it comes into contact with. Any type that is in a union, intersection, is a property of, or has any other relationship with an `any` type or value is erased and becomes an `any` type itself.
+  - This also means that `any` infects all surrounding and downstream code with its directive to suppress errors, expanding the surface area of code regarding which the TypeScript compiler can make no guarantees regarding type safety or runtime behavior.
 
 ```typescript
 // Type of 'payload_0': 'any'
@@ -310,11 +311,9 @@ const handler:
   | ((payload_0: ComposableControllerState, payload_1: Patch[]) => void)
   | ((payload_0: any, payload_1: Patch[]) => void);
 ```
+<!-- TODO: Add more examples: For instance, if you have a function that is declared to return any which actually returns an object, all properties of that object will be any. -->
 
-<!-- TODO: Add more examples -->
-
-- `any` pollutes all surrounding and downstream code.
-<!-- TODO: Add examples -->
+- From this follows the most dangerous characteristic of `any`: it infects all surrounding and downstream code with its directive to suppress errors, expanding the surface area of code for which the TypeScript compiler can make no guarantees regarding type safety or runtime behavior.
 
 ##### Try `unknown` and `never` instead
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -401,43 +401,7 @@ delete addressBook[chainId as unknown as `0x${string}`];
 
 When a type assertion is used with a clear rationale, we should document the reasoning behind its usage in the form of a comment.
 
-- A type assertion may be necessary to satisfy constraints, or to align with a type which is verified to be accurate by an external source of truth.
-
-  **Example <a id="example-05558b5e-527e-46b0-8b40-918f28d05156"></a> ([🔗 permalink](#example-05558b5e-527e-46b0-8b40-918f28d05156)):**
-
-  ✅
-
-  ```typescript
-  import contractMap from '@metamask/contract-metadata';
-
-  type LegacyToken = {
-    name: string;
-    logo: `${string}.svg`;
-    symbol: string;
-    decimals: number;
-    erc20?: boolean;
-    erc721?: boolean;
-  };
-
-  export const STATIC_MAINNET_TOKEN_LIST = Object.entries(
-    // This type assertion is to the known schema of the JSON object `contractMap`.
-    contractMap as Record<Hex, LegacyToken>,
-  ).reduce((acc, [base, contract]) => {
-    const { name, symbol, decimals, logo, erc721 } = contract;
-    return {
-      ...acc,
-      [base.toLowerCase()]: {
-        ...{ name, symbol, decimals },
-        address: base.toLowerCase(),
-        iconUrl: `images/contract/${logo}`,
-        isERC721: erc721 ?? false
-        aggregators: [],
-      },
-    };
-  }, {});
-  ```
-
-- A type assertion may be safe if it's supported by runtime validations.
+- A type assertion may be necessary to satisfy constraints. To be used safely, it must be supported by runtime validations.
 
   **Example <a id="example-81737669-75fb-46d6-b2ce-c09acd5b89ab"></a> ([🔗 permalink](#example-81737669-75fb-46d6-b2ce-c09acd5b89ab)):**
 
@@ -481,6 +445,37 @@ When a type assertion is used with a clear rationale, we should document the rea
     }
     ...
   }
+  ```
+
+- A type assertion may be necessary to align with a type which is verified to be accurate by an external source of truth. To be used safely, it must be supported by runtime validations.
+
+  **Example <a id="example-05558b5e-527e-46b0-8b40-918f28d05156"></a> ([🔗 permalink](#example-05558b5e-527e-46b0-8b40-918f28d05156)):**
+
+  ✅
+
+  ```typescript
+  import contractMap from '@metamask/contract-metadata';
+
+  type LegacyToken = {
+    name: string;
+    logo: `${string}.svg`;
+    symbol: string;
+    decimals: number;
+    erc20?: boolean;
+    erc721?: boolean;
+  };
+
+  export const STATIC_MAINNET_TOKEN_LIST = Object.entries(
+    // This type assertion is to the known schema of the JSON object `contractMap`.
+    contractMap as Record<Hex, LegacyToken>,
+  ).reduce((acc, [base, contract]) => {
+    const { name, symbol, decimals, logo, erc20, erc721 } = contract;
+    // The required properties are validated at runtime
+    if ([name, symbol, decimals, logo].some((e) => !e)) {
+      return;
+    }
+    ...
+  }, {});
   ```
 
 - Rarely, a type assertion may be necessary to resolve or suppress a type error caused by a bug or limitation of an external library, or even the TypeScript language itself.

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -167,7 +167,7 @@ const updatedTransactionMeta = {
 updatedTransactionMeta.error; // Property 'error' does not exist on type '{ status: TransactionStatus.rejected; ... }'.(2339)
 ```
 
-##### When instantiating an empty composite data-type value, provide a type annotation
+##### Provide a type annotation When instantiating an empty composite data-type value
 
 This is a special case where type inference cannot be expected to reach a useful conclusion without user-provided information.
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -19,9 +19,9 @@ TypeScript is very good at inferring types. Explicit type annotations and assert
 
 Some fundamental type information must always be supplied by the user, such as function and class signatures, interfaces for interacting with external entities or data types, and types that express the domain model of the codebase.
 
-However, for the remaining majority of types and values, **type inference should be preferred over type annotations and assertions**.
+However, for the remaining majority of types and values, type inference should be preferred over type annotations and assertions.
 
-##### Type inference should be preferred over explicit annotations and assertions
+##### Prefer type inference over annotations and assertions
 
 - Explicit type annotations (`:`) and type assertions (`as`, `!`) prevent further inference-based narrowing of the user-supplied types.
   - The compiler errs on the side of trusting user input, which prevents it from providing additional type information that it is able to infer.
@@ -111,7 +111,7 @@ const BUILT_IN_NETWORKS = {
 } as const; // Type { readonly mainnet: '0x1'; readonly sepolia: '0xaa36a7'; }
 ```
 
-### Type Narrowing
+### Type Annotations
 
 An explicit type annotation is acceptable to use for overriding an inferred type if...
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -4,14 +4,14 @@ These guidelines specifically apply to TypeScript.
 
 ## Types
 
-TypeScript provides a range of syntax with which to communicate type information with the compiler.
+TypeScript provides a range of syntax for communicating type information with the compiler.
 
 - The compiler performs **type inference** on all types and values in the code.
-- The user can assign **type annotations** (`:`) to override some of the inferred types.
-- The user can also add **type assertions** (`as`, `!`) to force the compiler to adhere to the user-supplied type even if it contradicts the compiler's inferences.
-- Finally, there are **compiler directives** for disabling type checking (`any`, `@ts-expect-error`) for a limited scope of code.
+- The user can assign **type annotations** (`:`) to override inferred types or add type constraints.
+- The user can add **type assertions** (`as`, `!`) to force the compiler to accept user-supplied types even if they contradicts the inferred types.
+- Finally, there are **compiler directives** that let type checking be disabled (`any`, `@ts-expect-error`) for a limited scope of code.
 
-The general order of preference for using these features coincides with the order in which they were just presented.
+The order of this list represents the general order of preference for using these features.
 
 ### Type Inference
 
@@ -19,14 +19,14 @@ TypeScript is very good at inferring types. Explicit type annotations and assert
 
 Some fundamental type information must always be supplied by the user, such as function and class signatures, interfaces for interacting with external entities or data types, and types that express the domain model of the codebase.
 
-However, for the remaining majority of types and values, inference should be preferred over annotations and assertions.
+However, for most types, inference should be preferred over annotations and assertions.
 
 ##### Prefer type inference over annotations and assertions
 
-- Explicit type annotations (`:`) and type assertions (`as`, `!`) prevent further inference-based narrowing of the user-supplied types.
+- Explicit type annotations (`:`) and type assertions (`as`, `!`) prevent inference-based narrowing of the user-supplied types.
   - The compiler errs on the side of trusting user input, which prevents it from utilizing additional type information that it is able to infer.
 - Type inferences are responsive to changes in code without requiring user input, while annotations and assertions rely on hard-coding, making them brittle against code drift.
-- The `as const` operator can be used to narrow an inferred abstract type into a specific literal type. It can also be used on arrays and objects to achieve the same effect on their properties.
+- The `as const` operator can be used to narrow an inferred abstract type into a specific literal type. It can also be used on arrays and objects to achieve the same effect on their elements.
 
 ##### Avoid unintentionally widening an inferred type with a type annotation
 
@@ -118,7 +118,7 @@ An explicit type annotation is acceptable for overriding an inferred type if...
 
 It is possible to use type annotations in two different ways: to assign a type definition, or to enforce a type constraint.
 
-In the second case, an abstract, "narrowest supertype" is used to constrain or validate a type. Since v4.9, TypeScript provides the `satisfies` operator for this use case. It is able to both enforce a type constraint and further narrow the assigned type through inference.
+In the second case, an abstract, "narrowest supertype" is used to constrain or validate a type. TypeScript provides the `satisfies` operator for this use case. It is able to both enforce a type constraint and further narrow the assigned type through inference.
 
 🚫 Use a type annotation for type validation
 
@@ -192,7 +192,7 @@ This can cause silent failures or false negatives where errors are suppressed. T
 
 ##### Redundant or unnecessary `as` assertions are not flagged for removal
 
-Type assertions can also cause false positives, because they assertions are independent expressions, untied to the type errors they were intended to fix. Thus, even if code drift fixes or removes a particular type error, the type assertions that were put in place to fix that error will provide no indication that they are no longer necessary and now should be removed.
+Type assertions can also cause false positives, because assertions are independent expressions, untied to the type errors they were intended to fix. Even if code drift fixes or removes a particular type error, the type assertions that were put in place to fix that error will provide no indication that they are no longer necessary and now should be removed.
 
 ```typescript
 enum Direction {
@@ -288,13 +288,13 @@ nftMetadataResults.filter(
 
 ##### `as` is acceptable to use for preventing or fixing `any` usage
 
-Unsafe as type assertions may be, they are still categorically preferable to using `any`.
+Unsafe as type assertions may be, they should always be preferred to introducing `any` into the code.
 
 - With type assertions, we still get working intellisense, autocomplete, and other IDE and compiler features using the asserted type.
-- Type assertions also provide an indication of what the expected type is as intended by the author.
-- For type assertions to an incompatible shape, use `as unknown as` as a last resort rather than `any` or `as any`.
+- Type assertions also provide an indication of what the author intends or expects the type to be.
 - Often, the compiler will tell us exactly what the target type for an assertion needs to be, enabling us to avoid `as any`.
-- Even an assertion to a wrong type still allows the compiler to show us warnings and errors as the code changes, and is therefore preferrable to the complete radio silence enforced by `any`.
+- Even an assertion to a wrong type still allows the compiler to show us warnings and errors as the code changes, and is therefore preferrable to the dangerous radio silence enforced by `any`.
+- For type assertions to an incompatible shape, use `as unknown as` as a last resort rather than `any` or `as any`.
 
 ```typescript
 // Error: Argument of type '"getNftInformation"' is not assignable to parameter of type 'keyof NftController'.ts(2345)
@@ -347,7 +347,7 @@ Preferably, this typing should be accompanied by runtime schema validation perfo
 
 It's recommended to provide accurate typing if there's any chance that omitting properties affects the accuracy of the test.
 
-If that is not the case, however, mocking only the properties needed in the test improves readability. It makes the intention and scope of the mock clear, and is much more convenient to write.
+If that is not the case, however, mocking only the properties needed in the test improves readability. It makes the intention and scope of the mock clear, and is more convenient to write, which can encourage test writing and improve test coverage.
 
 ### Compiler Directives
 
@@ -357,10 +357,10 @@ If that is not the case, however, mocking only the properties needed in the test
 
 `any` is the most dangerous form of explicit type declaration, and should be completely avoided.
 
-The key thing to remember about `any` is that it does not resolve errors, but only hides them. The errors still affect the code, only now it's impossible to assess and counteract their destructive influence.
+The key thing to remember about `any` is that it does not resolve errors, but only hides them. The errors still affect the code, only now it's impossible to assess and counteract their influence.
 
 - `any` doesn't represent the widest type, or indeed any type at all. `any` is a compiler directive for _disabling_ static type checking for the value or type to which it's assigned.
-- `any` suppresses all error messages about its assignee. This makes code with `any` usage brittle against changes, since the compiler is unable to update its feedback even when the code is changed enough to alter, remove, or add new type errors.
+- `any` suppresses all error messages about its assignee. This makes code with `any` usage brittle against changes, since the compiler is unable to update its feedback even when the code has changed enough to alter, remove, or add new type errors.
 - `any` subsumes all other types it comes into contact with. Any type that is in a union, intersection, is a property of, or has any other relationship with an `any` type or value becomes an `any` type itself. This represents an unmitigated loss of type information.
 
 ```typescript
@@ -376,9 +376,9 @@ function returnsAny(): any {
 const { a, b, c } = returnsAny();
 ```
 
-- `any` infects all surrounding and downstream code with its directive to suppress errors. This is the most dangerous characteristic of `any`, as it causes the encroachment of unchecked code for which the TypeScript compiler can make no guarantees regarding type safety or runtime behavior.
+- `any` infects all surrounding and downstream code with its directive to suppress errors. This is the most dangerous characteristic of `any`, as it causes the encroachment of unsafe code, for which the TypeScript compiler can make no guarantees on type safety or runtime behavior.
 
-All of this makes `any` a prominent cause of dangerous **silent failures**, where the code fails at runtime but the compiler does not provide any prior warning, defeating the purpose of using a statically-typed language.
+All of this makes `any` a prominent cause of dangerous **silent failures**, where the code fails at runtime but the compiler does not provide any prior warning, which defeats the purpose of using a statically-typed language.
 
 ##### When `any` , try `unknown` and `never` instead
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -6,16 +6,16 @@ These guidelines specifically apply to TypeScript.
 
 TypeScript provides a range of syntax with which to communicate type information with the compiler.
 
-- The compiler performs **type inference** on all types and values in the code, which forms the baseline for strong, static typing.
+- The compiler performs **type inference** on all types and values in the code.
 - The user can assign **type annotations** (`:`) to override some of the inferred types.
-- The user can perform **type assertions** (`as`, `!`) to force the compiler to adhere to the user-supplied type even if it contradicts the compiler's inferences.
-- There are even **compiler directives** for disabling type checking (`any`, `@ts-expect-error`) for a limited scope of code.
+- The user can also add **type assertions** (`as`, `!`) to force the compiler to adhere to the user-supplied type even if it contradicts the compiler's inferences.
+- Finally, there are **compiler directives** for disabling type checking (`any`, `@ts-expect-error`) for a limited scope of code.
 
-fThe general order of preference for using these language features coincides with the order in which they were just presented.
+The general order of preference for using these features coincides with the order in which they were just presented.
 
 ### Type Inference
 
-TypeScript is very good at inferring types. Explicit type annotations and assertions are the exception rather than the rule in a well-managed TypeScript codebase with strong type safety guarantees.
+TypeScript is very good at inferring types. Explicit type annotations and assertions are the exception rather than the rule in a well-managed TypeScript codebase even with strong type safety guarantees.
 
 Some fundamental type information must always be supplied by the user, such as function and class signatures, interfaces for interacting with external entities or data types, and types that express the domain model of the codebase.
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -420,7 +420,7 @@ When a type assertion is used with a clear rationale, we should document the rea
   };
 
   export const STATIC_MAINNET_TOKEN_LIST = Object.entries(
-    // This type assertion is to the known schema of the JSON object `contract-metadata.json`.
+    // This type assertion is to the known schema of the JSON object `contractMap`.
     contractMap as Record<Hex, LegacyToken>,
   ).reduce((acc, [base, contract]) => {
     const { name, symbol, decimals, logo, erc721 } = contract;
@@ -526,7 +526,7 @@ When a type assertion is used with a clear rationale, we should document the rea
 
 ### Escape Hatches
 
-TypeScript provides several escape hatches that disable compiler type checks altogether and suppress compiler errors. Using these to ignore typing issues is dangerous and reduces the effectiveness of TypeScript. The following are presented in order of preference for usage.
+TypeScript provides several escape hatches that disable compiler type checks altogether and suppress compiler errors. Using these to ignore typing issues is dangerous and reduces the effectiveness of TypeScript.
 
 - `@ts-expect-error`
   - Applies to a single line, which may contain multiple variables and errors.
@@ -549,7 +549,7 @@ TypeScript provides several escape hatches that disable compiler type checks alt
   - Does not propagate to instances of the target variable or type that are outside of its scope.
   - Banned by the `@typescript-eslint/ban-ts-comment` rule.
 
-- `any`:
+- `any`
   - Applies to all instances of the target variable or type throughout the entire codebase, and in downstream code as well.
   - Has the same effect as applying `@ts-ignore` to every single instance of the target variable or type.
   - Banned by the `@typescript-eslint/no-explicit-any` rule.
@@ -634,7 +634,7 @@ This recommendation applies to any disruptive change that creates many errors at
 
 See [this entry](https://github.com/MetaMask/core/blob/main/docs/package-migration-process-guide.md#4-resolve-or-todo-downstream-errors) in the core repo "package migration process guide," which recommends that complex or blocked errors should be annotated with a `// @ts-expect-error TODO:` comment, and then revisited once the disruptive change has been completed.
 
-#### Always avoid `any`
+#### Avoid `any`
 
 `any` is the most dangerous form of explicit type declaration, and should be completely avoided.
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -25,8 +25,6 @@ However, for the remaining majority of types and values, type inference should b
 
 - Explicit type annotations (`:`) and type assertions (`as`, `!`) prevent further inference-based narrowing of the user-supplied types.
   - The compiler errs on the side of trusting user input, which prevents it from providing additional type information that it is able to infer.
-  - To resolve this limitation, the `satisfies` operator was introduced in TypeScript v4.9, which can be used to assign type constraints that are narrowable through type inference.
-    <!-- TODO: Add examples -->
 - Type inferences are responsive to changes in code without requiring user input, while annotations and assertions rely on hard-coding, making them brittle against code drift.
 - The `as const` operator can be used to narrow an inferred abstract type into a specific literal type.
 
@@ -117,6 +115,18 @@ An explicit type annotation is acceptable to use for overriding an inferred type
 
 1) It can further narrow an inferred type, thus supplying type information that the compiler cannot infer or access.
 2) It is determined to be the most accurate _and_ specific type assignable.
+
+##### Use the `satisfies` operator to enforce a type constraint or to validate the assigned type
+
+These requirements can be confusing because it is possible to use type annotations in two different ways: to assign a type definition, or to enforce a type constraint.
+
+In the second case, an abstract, "narrowest supertype" is used to constrain or validate a type. Since v4.9, TypeScript provides the `satisfies` operator for this use case. It is able to both enforce a type constraint and further narrow the assigned type through inference.
+
+<!-- TODO: Add examples -->
+
+However, for mature, well-maintained codebases with minimal usage of `any`, it is also worth considering whether a type validation at the source of the type declaration is necessary, when the assigned type will be subject to a type check downstream wherever it ends up being called or used.
+
+Therefore, `satisfies` should only be used when the user-supplied abstract type provides more type information and useful context than the most specific type definition.
 
 #### Acceptable usages of `:` annotations
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -4,13 +4,22 @@ These guidelines specifically apply to TypeScript.
 
 ## Types
 
+TypeScript provides a range of syntax with which to communicate type information with the compiler.
+
+- The compiler performs **type inference** on all types and values in the code, which forms the baseline for strong, static typing.
+- The user can assign **type annotations** (`:`) to override some of the inferred types.
+- The user can perform **type assertions** (`as`, `!`) to force the compiler to adhere to the user-supplied type even if it contradicts the compiler's inferences.
+- There are even **compiler directives** for disabling type checking (`any`, `@ts-expect-error`) for a limited scope of code.
+
+The general order of preference for using these language features coincides with the order in which they were just presented.
+
 ### Type Inference
 
 TypeScript is very good at inferring types. Explicit type annotations and assertions are the exception rather than the rule in a well-managed TypeScript codebase with strong type safety guarantees.
 
 Some fundamental type information must always be supplied by the user, such as function and class signatures, interfaces for interacting with external entities or data types, and types that express the domain model of the codebase.
 
-However, for the remaining majority of types and values, **type inference should generally be preferred over type annotations and assertions**.
+However, for the remaining majority of types and values, **type inference should be preferred over type annotations and assertions**.
 
 ##### Type inference should be preferred over explicit annotations and assertions
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -630,14 +630,17 @@ See [this entry](https://github.com/MetaMask/core/blob/main/docs/package-migrati
 
 `any` is the most dangerous form of explicit type declaration, and should be completely avoided.
 
-Unfortunately, `any` is also such a tempting escape hatch from the TypeScript type system that there's a strong incentive to use it whenever a nontrivial typing issue is encountered. Entire teams can easily be enticed into a pattern of unblocking feature development by introducing `any` with the intention of fixing it later. This is a major source of tech debt, and its destructive influence on the type safety of a codebase cannot be understated.
+Unfortunately, when confronted with nontrivial typing issues, there's a very strong incentive to use `any` to bypass the TypeScript type system.
 
-Therefore, to prevent new `any` instances from being introduced into our codebase, it is not enough to rely on the `@typescript-eslint/no-explicit-any` ESLint rule. It's also necessary for all contributors to understand exactly why `any` is dangerous, and how it can be avoided.
+It's very easy for teams to fall into a pattern of unblocking feature development using `any`, with the intention of fixing it later. This is a major source of tech debt, and the destructive influence of `any` usage on the type safety of a codebase cannot be understated.
 
-The key thing to remember about `any` is that it does not resolve errors, but only hides them. The errors still affect the code, while `any` makes it impossible to assess and counteract their influence.
+To prevent `any` instances from being introduced into the codebase, it is not enough to rely on the `@typescript-eslint/no-explicit-any` ESLint rule. It's also necessary for all contributors to share a common understanding of exactly why `any` is dangerous, and how it can be avoided.
 
-- `any` doesn't represent the widest type, or indeed any type at all. `any` is a compiler directive for _disabling_ static type checking for the value or type to which it's assigned.
-- `any` suppresses all error messages about its assignee. This makes code with `any` usage brittle against changes, since the compiler is unable to update its feedback even when the code has changed enough to alter or remove the error, or even add new type errors.
+- `any` does not represent the widest type. In fact, it is not a type at all. `any` is a compiler directive for _disabling_ type checking for the value or type to which it's assigned.
+- `any` suppresses all error messages about its assignee.
+  - The suppressed errors still affect the code, but `any` makes it impossible to assess and counteract their influence.
+  - Much like type assertions, code with `any` usage becomes brittle against changes, since the compiler is unable to update its feedback even if the suppressed error has been altered, or entirely new type errors have been added.
+
 - `any` subsumes all other types it comes into contact with. Any type that is in a union, intersection, is a property of, or has any other relationship with an `any` type or value becomes an `any` type itself. This represents an unmitigated loss of type information.
 
   **Example <a id="example-1fb5b0ad-61a9-4ad8-9d84-e29b78d88325"></a> ([🔗 permalink](#example-1fb5b0ad-61a9-4ad8-9d84-e29b78d88325)):**

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -111,22 +111,38 @@ const BUILT_IN_NETWORKS = {
 
 ### Type Annotations
 
-An explicit type annotation is acceptable to use for overriding an inferred type if...
+An explicit type annotation is acceptable for overriding an inferred type if...
 
-1) It can further narrow an inferred type, thus supplying type information that the compiler cannot infer or access.
-2) It is determined to be the most accurate _and_ specific type assignable.
+1. It can further narrow an inferred type, thus supplying type information that the compiler cannot infer or access.
+2. It is determined to be the most accurate _and_ specific type assignable.
 
 ##### Use the `satisfies` operator to enforce a type constraint or to validate the assigned type
 
-These requirements can be confusing because it is possible to use type annotations in two different ways: to assign a type definition, or to enforce a type constraint.
+It is possible to use type annotations in two different ways: to assign a type definition, or to enforce a type constraint.
 
 In the second case, an abstract, "narrowest supertype" is used to constrain or validate a type. Since v4.9, TypeScript provides the `satisfies` operator for this use case. It is able to both enforce a type constraint and further narrow the assigned type through inference.
 
-<!-- TODO: Add examples -->
+🚫 Use a type annotation for type validation
 
-However, for mature, well-maintained codebases with minimal usage of `any`, it is also worth considering whether a type validation at the source of the type declaration is necessary, when the assigned type will be subject to a type check downstream wherever it ends up being called or used.
+```typescript
+const updatedTransactionMeta: TransactionMeta = {
+  ...transactionMeta,
+  status: TransactionStatus.rejected,
+};
 
-Therefore, `satisfies` should only be used when the user-supplied abstract type provides more type information and useful context than the most specific type definition.
+updatedTransactionMeta.error; // Type 'TransactionError'
+```
+
+✅ Use the `satisfies` operator for type validation
+
+```typescript
+const updatedTransactionMeta = {
+  ...transactionMeta,
+  status: TransactionStatus.rejected as const,
+} satisfies TransactionMeta;
+
+updatedTransactionMeta.error; // Type 'undefined'
+```
 
 #### Acceptable usages of `:` annotations
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -137,6 +137,8 @@ Introduced in [TypeScript 4.9](https://devblogs.microsoft.com/typescript/announc
 
 **Example <a id="example-21ed5949-8d34-4754-b806-412de1696f46"></a> ([🔗 permalink](#example-21ed5949-8d34-4754-b806-412de1696f46)):**
 
+(continued from [previous example](#example-e9b0d703-032d-428b-a232-f5aa56a94470))
+
 🚫 Use a type annotation for type validation
 
 ```typescript

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -355,21 +355,30 @@ If that is not the case, however, mocking only the properties needed in the test
 
 #### Avoid `any`
 
-`any` is the most dangerous form of explicit type declaration, and should be completely avoided if possible.
+`any` is the most dangerous form of explicit type declaration, and should be completely avoided.
+
+The key thing to remember about `any` is that it does not resolve errors, but only hides them. The errors still affect the code, only now it's impossible to assess and counteract their destructive influence.
 
 - `any` doesn't represent the widest type, or indeed any type at all. `any` is a compiler directive for _disabling_ static type checking for the value or type to which it's assigned.
-- `any` suppresses all error messages about its assignee. This includes errors that are changed or newly introduced by alterations to the code. This makes `any` the cause of dangerous **silent failures**, where the code fails at runtime but the compiler does not provide any prior warning.
-- `any` subsumes all other types it comes into contact with. Any type that is in a union, intersection, is a property of, or has any other relationship with an `any` type or value is erased and becomes an `any` type itself.
+- `any` suppresses all error messages about its assignee. This makes code with `any` usage brittle against changes, since the compiler is unable to update its feedback even when the code is changed enough to alter, remove, or add new type errors.
+- `any` subsumes all other types it comes into contact with. Any type that is in a union, intersection, is a property of, or has any other relationship with an `any` type or value becomes an `any` type itself. This represents an unmitigated loss of type information.
 
 ```typescript
 // Type of 'payload_0': 'any'
 const handler:
   | ((payload_0: ComposableControllerState, payload_1: Patch[]) => void)
   | ((payload_0: any, payload_1: Patch[]) => void);
-```
-<!-- TODO: Add more examples: For instance, if you have a function that is declared to return any which actually returns an object, all properties of that object will be any. -->
 
-- Because of this, `any` infects all surrounding and downstream code with its directive to suppress errors. This is the most dangerous characteristic of `any`, as it expands the surface area of unchecked code for which the TypeScript compiler can make no guarantees regarding type safety or runtime behavior.
+function returnsAny(): any {
+  return { a: 1, b: true, c: 'c' };
+}
+// Types of a, b, c are all `any`
+const { a, b, c } = returnsAny();
+```
+
+- `any` infects all surrounding and downstream code with its directive to suppress errors. This is the most dangerous characteristic of `any`, as it causes the encroachment of unchecked code for which the TypeScript compiler can make no guarantees regarding type safety or runtime behavior.
+
+All of this makes `any` a prominent cause of dangerous **silent failures**, where the code fails at runtime but the compiler does not provide any prior warning, defeating the purpose of using a statically-typed language.
 
 ##### Try `unknown` and `never` instead
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -1,6 +1,16 @@
 # TypeScript Guidelines
 
-These guidelines specifically apply to TypeScript.
+The purpose of this article is to:
+
+- Present best practices and preferred conventions for contributing type-safe and maintainable TypeScript to MetaMask repos.
+- Cultivate a shared understanding of advanced concepts to prevent recurring issues that cannot be addressed with blind compliance alone.
+- Serve as a reference during code review to lend weight to preferred approaches, minimize redundant discussion, and educate contributors about established practices.
+
+This article does not aim to:
+
+- Serve as a comprehensive resource covering all major aspects of syntax and style.
+- Redundantly list or explain conventions that are enforceable through linters or static rulesets.
+- Endorse its contents as being appropriate or useful for any TypeScript codebase outside of our own.
 
 ## Types
 
@@ -11,7 +21,7 @@ TypeScript provides a range of syntax for communicating type information with th
 - The user can add **type assertions** (`as`, `!`) to force the compiler to accept user-supplied types even if they contradicts the inferred types.
 - Finally, there are **compiler directives** that let type checking be disabled (`any`, `@ts-expect-error`) for a limited scope of code.
 
-The order of this list represents the general order of preference for using these features.
+The order of this list represents the general order of preference for these features.
 
 ### Type Inference
 
@@ -353,9 +363,9 @@ If that is not the case, however, mocking only the properties needed in the test
 
 `any` is the most dangerous form of explicit type declaration, and should be completely avoided.
 
-Unfortunately, `any` is also such a tempting escape hatch from the TypeScript type system that there's a strong incentive to use it whenever a nontrivial typing issue is encountered. Entire teams can easily be enticed into "unblocking" feature development by temporarily using `any` with the intention of fixing it later. This is a major source of tech debt, and its destructive influence on the type safety of a codebase cannot be understated.
+Unfortunately, `any` is also such a tempting escape hatch from the TypeScript type system that there's a strong incentive to use it whenever a nontrivial typing issue is encountered. Entire teams can easily be enticed into "unblocking" feature development by temporarily using `any` with the intention of fixing it later. This is a major source of tech debt, and its destructive effect on the type safety of a codebase cannot be understated.
 
-Therefore, to prevent new `any` instances from being introduced into our codebase, we cannot rely on the `@typescript-eslint/no-explicit-any` ESLint rule. It's also necessary for all contributors to understand exactly why `any` is dangerous, and how it can be avoided.
+Therefore, to prevent new `any` instances from being introduced into our codebase, we cannot rely only on the `@typescript-eslint/no-explicit-any` ESLint rule. It's also necessary for all contributors to understand exactly why `any` is dangerous, and how it can be avoided.
 
 <!-- TODO: Add section for `@ts-expect-error` -->
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -337,13 +337,15 @@ nftMetadataResults.filter(
   );
 ```
 
-> Note: The [`is` assertion is unnecessary](https://github.com/microsoft/TypeScript/pull/57465) as of TypeScript v5.5.
+> Note: The `is` type predicate in this example [is unnecessary as of TypeScript v5.5](https://github.com/microsoft/TypeScript/pull/57465).
 
 #### Determine the target type for an `as` assertion by examining compiler error messages
 
+Often, the compiler will tell us exactly what the target type for an assertion needs to be.
+
 ##### **Example <a id="example-2ee8f56a-e3be-417b-a2c0-260c1319b755"></a> ([🔗 permalink](#example-2ee8f56a-e3be-417b-a2c0-260c1319b755)):**
 
-**Example <a id="example-2ee8f56a-e3be-417b-a2c0-260c1319b755"></a> ([🔗 permalink](#example-2ee8f56a-e3be-417b-a2c0-260c1319b755))**:
+🚫 Compiler specifies that the target type should be `keyof NftController`
 
 ```typescript
 // Error: Argument of type '"getNftInformation"' is not assignable to parameter of type 'keyof NftController'.ts(2345)
@@ -351,13 +353,7 @@ nftMetadataResults.filter(
 sinon.stub(nftController, 'getNftInformation');
 ```
 
-🚫 `as any`
-
-```typescript
-sinon.stub(nftController, 'getNftInformation' as any);
-```
-
-✅ Compiler specifies that the target type should be `keyof NftController`
+✅ `as` assertion to type specified by compiler
 
 ```typescript
 sinon.stub(nftController, 'getNftInformation' as keyof typeof nftController);

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -294,23 +294,24 @@ Unsafe as type assertions may be, they are still categorically preferable to usi
 - Type assertions also provide an indication of what the expected type is as intended by the author.
 - For type assertions to an incompatible shape, use `as unknown as` as a last resort rather than `any` or `as any`.
 - Often, the compiler will tell us exactly what the target type for an assertion needs to be, enabling us to avoid `as any`.
+- Even an assertion to a wrong type still allows the compiler to show us warnings and errors as the code changes, and is therefore preferrable to the complete radio silence enforced by `any`.
 
 ```typescript
 // Error: Argument of type '"getNftInformation"' is not assignable to parameter of type 'keyof NftController'.ts(2345)
 // 'getNftInformation' is a private method of class 'NftController'
-sinon.stub(nftController, 'getNftInformation')
+sinon.stub(nftController, 'getNftInformation');
 ```
 
 🚫 `as any`
 
 ```typescript
-sinon.stub(nftController, 'getNftInformation' as any)
+sinon.stub(nftController, 'getNftInformation' as any);
 ```
 
 ✅ Compiler specifies that the target type should be `keyof NftController`
 
 ```typescript
-sinon.stub(nftController, 'getNftInformation' as keyof typeof nftController)
+sinon.stub(nftController, 'getNftInformation' as keyof typeof nftController);
 ```
 
 ##### For TypeScript syntax other than type assertion

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -126,7 +126,7 @@ An explicit type annotation is acceptable for overriding an inferred type if...
 
 ##### Use the `satisfies` operator to enforce a type constraint or to validate the assigned type
 
-In the second case, an abstract, "narrowest supertype" is used to constrain or validate a type. TypeScript provides the `satisfies` operator for this use case. It is able to both enforce a type constraint and further narrow the assigned type through inference.
+TypeScript provides the `satisfies` operator for constraining or validating a type. It is able to both enforce a type constraint and further narrow the assigned type through inference.
 
 🚫 Use a type annotation for type validation
 
@@ -213,7 +213,7 @@ const directions = Object.values(Direction);
 
 // Error: Element implicitly has an 'any' type because index expression is not of type 'number'.(7015)
 // Only one of the two `as` assertions necessary to fix error, but neither are flagged as redundant.
-for (const key of Object.keys(directions) as keyof directions[]) {
+for (const key of Object.keys(directions) as (keyof typeof directions)[]) {
   const direction = directions[key as keyof typeof directions];
 }
 ```
@@ -235,7 +235,11 @@ function isSomeInterface(x: unknown): x is SomeInterface {
 
 ```typescript
 function f(x: SomeInterface | SomeOtherInterface) {
-  console.log((x as SomeInterface).name);
+  if (x.name) {
+    // We know that `x` is `SomeInterface` because `x` has a `name` but `SomeOtherInterface` does not
+    console.log((x as SomeInterface).name);
+  }
+
 }
 ```
 
@@ -244,7 +248,6 @@ function f(x: SomeInterface | SomeOtherInterface) {
 ```typescript
 function f(x: SomeInterface | SomeOtherInterface) {
   if (isSomeInterface(x)) {
-    // Type of x: 'SomeInterface | SomeOtherInterface'
     console.log(x.name); // Type of x: 'SomeInterface'. Type of x.name: 'string'.
   }
 }
@@ -370,7 +373,6 @@ TypeScript provides several directive comments that can be used to suppress Type
 
 Sometimes, there is a need to force a branch to execute at runtime for security or testing purposes, when that branch has correctly been inferred as being inaccessible by the TypeScript compiler.
 
-Suppressing compiler errors to avoid typing issues is usually dangerous because it results in a loss of information and safety. However, consciously using `@ts-expect-error` to add runtime checks represents an improvement in these aspects, and therefore is not discouraged.
 
 ✅
 
@@ -573,15 +575,6 @@ class BaseController<
 - In general, using `any` in this context is not harmful in the same way that it is in other contexts, as the `any` types only are not directly assigned to any specific variable, and only function as constraints.
 - That said, more specific constraints provide better type safety and intellisense, and should be preferred wherever possible.
 
-##### `any` may be acceptable to use to type the error property in a catch block
-
-- `catch` only accepts `any` and `unknown` as the error type.
-- Recommended: Use `unknown` with type guards like `isJsonRpcError`.
-- Avoid typing an error object with `any` if it is passed on to be used elsewhere instead of just being thrown, as the `any` type will infect the downstream code.
-
-##### `any` may be acceptable to use in tests, to intentionally break features
-
-<!-- TODO: Add examples. Should be clear why type assertions couldn't be used instead -->
 
 ## Functions
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -387,28 +387,6 @@ sinon.stub(nftController, 'getNftInformation' as keyof typeof nftController);
 - For type assertions to an incompatible shape, use `as unknown as` as a last resort rather than `any` or `as any`.
 <!-- TODO: Add example -->
 
-##### `as` is always acceptable to use for TypeScript syntax other than type assertion
-
-- Writing type guards often requires using the `as` keyword.
-
-###### Example (f16df571-266e-4030-b002-49554558ccd7)
-
-```typescript
-function isFish(pet: Fish | Bird): pet is Fish {
-  return (pet as Fish).swim !== undefined;
-}
-```
-
-- Key remapping in mapped types uses the `as` keyword.
-
-###### Example (6ffd8c99-4768-42e1-8cb7-5710d14f8552)
-
-```typescript
-type MappedTypeWithNewProperties<Type> = {
-  [Properties in keyof Type as NewKeyType]: Type[Properties];
-};
-```
-
 ##### `as` is acceptable to use for typing data objects whose shape and contents are determined at runtime, externally, or through deserialization
 
 Preferably, this typing should be accompanied by runtime schema validation performed with type guards and unit tests.
@@ -425,6 +403,20 @@ It's recommended to provide accurate typing if there's any chance that omitting 
 If that is not the case, however, mocking only the properties needed in the test improves readability. It makes the intention and scope of the mock clear, and is more convenient to write, which can encourage test writing and improve test coverage.
 
 <!-- TODO: Add examples -->
+
+#### `as` is always acceptable to use in the context of TypeScript syntax that does not involve type assertions
+
+- `as const` assertions.
+
+- Key remapping in mapped types uses the `as` keyword.
+
+###### Example (6ffd8c99-4768-42e1-8cb7-5710d14f8552)
+
+```typescript
+type MappedTypeWithNewProperties<Type> = {
+  [Properties in keyof Type as NewKeyType]: Type[Properties];
+};
+```
 
 ### Escape Hatches
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -27,7 +27,7 @@ TypeScript provides a range of syntax for communicating type information with th
 - The compiler performs **type inference** on all types and values in the code.
 - The user can assign **type annotations** (`:`) to override inferred types or add type constraints.
 - The user can add **type assertions** (`as`, `!`) to force the compiler to accept user-supplied types even if they contradicts the inferred types.
-- Finally, there are **compiler directives** that let type checking be disabled (`any`, `@ts-expect-error`) for a certain scope of code.
+- Finally, there are **escape hatches** that let type checking be disabled (`any`, `@ts-expect-error`) for a certain scope of code.
 
 The order of this list represents the general order of preference for using these features.
 
@@ -393,21 +393,32 @@ If that is not the case, however, mocking only the properties needed in the test
 
 <!-- TODO: Add examples -->
 
-### Compiler Directives
+### Escape Hatches
 
-TypeScript provides several directive comments that can be used to suppress TypeScript compiler errors. Using these to ignore typing issues is dangerous and reduces the overall effectiveness of TypeScript.
+TypeScript provides several escape hatches that disable compiler type checks altogether and suppress compiler errors. Using these to ignore typing issues is dangerous and reduces the effectiveness of TypeScript.
 
-Of these, we will discuss the use cases and pitfalls of `@ts-expect-error` and `any`.
+- `@ts-expect-error`
+  - Applies to a single line, which may contain multiple variables and errors.
+  - Is allowed by the ESLint rule `@typescript-eslint/ban-ts-comment`, but is required to be accompanied by an explanation comment.
+  - **It alerts users if an error it was suppressing has been resolved by changes in the code**:
+    > **Error:** Unused '@ts-expect-error' directive.
+  
+- `as any`
+  - Applies to a single instance of a single variable.
+  - Is banned by the ESLint rule `@typescript-eslint/no-explicit-any.
 
-`@ts-ignore`, `@ts-nocheck`, `@ts-check` are disabled by ESLint rules.
+- `@ts-ignore`
+  - Applies to a line or block of code, which may contain multiple variables and errors.
+  - Is banned by the ESLint rule `@typescript-eslint/ban-ts-comment`.
+
+- `any`:
+  - Applies to all instances of the target variable or type throughout the entire codebase, and in downstream code as well.
+  - Is banned by the ESLint rule `@typescript-eslint/no-explicit-any.
+  - Has the same effect as applying `@ts-ignore` to every single instance of the target variable or type.
 
 #### Acceptable usages of `@ts-expect-error`
 
-##### Prefer `@ts-expect-error` over `any`
-
-`@ts-expect-error` is a better alternative to `any` or `as`, because if the error it was suppressing has been resolved by changes in the code, it will alert users with the following message:
-
-> **Error:** Unused '@ts-expect-error' directive.
+In general, `@ts-expect-error` usage should be reserved to situations where an error is the intended or expected result of an operation, not to silence errors when the correct typing solution couldn't be found.
 
 ##### Use `@ts-expect-error` to force runtime execution of a branch for validation or testing
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -258,8 +258,6 @@ mockGetNetworkConfigurationByNetworkClientId.mockImplementation(
 // Target signature provides too few arguments. Expected 2 or more, but got 1.ts(2345)
 ```
 
-#### Fixes for `any`
-
 ##### Try `unknown` and `never` instead
 
 ###### `unknown`

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -344,7 +344,7 @@ const handler:
 ```
 <!-- TODO: Add more examples: For instance, if you have a function that is declared to return any which actually returns an object, all properties of that object will be any. -->
 
-- From this follows the most dangerous characteristic of `any`: it infects all surrounding and downstream code with its directive to suppress errors, expanding the surface area of code for which the TypeScript compiler can make no guarantees regarding type safety or runtime behavior.
+- Because of this, `any` infects all surrounding and downstream code with its directive to suppress errors. This is the most dangerous characteristic of `any`, as it expands the surface area of unchecked code for which the TypeScript compiler can make no guarantees regarding type safety or runtime behavior.
 
 ##### Try `unknown` and `never` instead
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -266,6 +266,9 @@ for (const key of Object.keys(directions) as (keyof typeof directions)[]) {
 ##### **Example <a id="example-50c3fbc9-c2d7-4140-9f75-be5f0a56d541"></a> ([🔗 permalink](#example-50c3fbc9-c2d7-4140-9f75-be5f0a56d541)):**
 
 ```typescript
+type SomeInterface = { name: string; length: number };
+type SomeOtherInterface = { value: boolean };
+
 function isSomeInterface(x: unknown): x is SomeInterface {
   return (
     'name' in x &&
@@ -280,10 +283,7 @@ function isSomeInterface(x: unknown): x is SomeInterface {
 
 ```typescript
 function f(x: SomeInterface | SomeOtherInterface) {
-  if (x.name) {
-    // We know that `x` is `SomeInterface` because `x` has a `name` but `SomeOtherInterface` does not
-    console.log((x as SomeInterface).name);
-  }
+  console.log((x as SomeInterface).name);
 }
 ```
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -491,9 +491,7 @@ const { a, b, c } = returnsAny();
 
 All of this makes `any` a prominent cause of dangerous **silent failures** (false negatives), where the code fails at runtime but the compiler does not provide any prior warning, which defeats the purpose of using a statically-typed language.
 
-##### When tempted to use `any`, try `unknown` and `never` instead
-
-###### `unknown`
+##### If `any` is being used as the _assignee_ type, use `unknown` instead
 
 `any` usage is often motivated by a need to find a placeholder type that could be anything. `unknown` is the most likely type-safe substitute for `any` in these cases.
 
@@ -501,18 +499,39 @@ All of this makes `any` a prominent cause of dangerous **silent failures** (fals
 - Every type is assignable to `unknown`, but `unknown` is only assignable to `unknown`.
 - When typing the _assignee_, `any` and `unknown` are completely interchangeable since every type is assignable to both.
 
-###### `never`
+##### If `any` is being used as the _assigned_ type, find an appropriate subtype of the _assignee_ type
 
-`never` is worth trying as a starting point for narrowing down the type, as it is the universal subtype and assignable to all types.
+Unfortunately, when typing the _assigned_ type, `unknown` cannot substitute `any` in most cases, because:
 
-- `never` is the universal subtype i.e. the narrowest possible type, equivalent to the null set(∅).
-- `never` is assignable to every type, but the only type that is assignable to `never` is `never`.
-- When typing the _assigned_:
-  - `unknown` is unable to replace `any`, as `unknown` is only assignable to `unknown`.
-  - The type of the _assigned_ must be a subtype of the _assignee_.
-  - If the assigned type simultaneously needs to be the assignee for another type, `never` will not work, as no type is assignable to `never`.
+- `unknown` is only assignable to `unknown`.
+- The type of the _assigned_ must be a subtype of the _assignee_, but `unknown` can only be a subtype of `unknown`.
 
-<!-- TODO: Add examples -->
+###### Example (56165606-17db-479d-a2f7-cc95250f2129)
+
+```typescript
+function f1(arg1: string) { ... }
+function f2(arg2: any) {
+  f1(arg2) // `arg1` is the assignee type, and `arg2` is the assigned type.
+}
+```
+
+🚫 `unknown`
+
+```typescript
+function f1(arg1: string) { ... }
+function f2(arg2: unknown) {
+  f1(arg2) // Error: Argument of type 'unknown' is not assignable to parameter of type 'string'.(2345)
+}
+```
+
+✅ Subtype of `string`, the assignee type
+
+```typescript
+function f1(arg1: string) { ... }
+function f2(arg2: `0x${string}`) {
+  f1(arg2) 
+}
+```
 
 ##### Don't allow `any` to be used as a generic default argument
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -1,8 +1,10 @@
 # TypeScript Guidelines
 
+The TypeScript Guidelines establishes stylistic conventions and best practices for contributing TypeScript code to the MetaMask codebase.
+
 ## Introduction
 
-This document is not intended as a stand-in for linters or formatters. Emphasis is put on discussing underlying concepts and rationale, rather than listing rules and restrictions.
+This document is intended to complement linters and formatters. Emphasis is put on discussing underlying concepts and rationale, rather than listing rules and restrictions.
 
 Type safety and maintainability are the highest priorities in these guidelines, even if that sometimes leads to unconventional or opinionated recommendations.
 
@@ -640,7 +642,6 @@ To prevent `any` instances from being introduced into the codebase, it is not en
 
   - The suppressed errors still affect the code, but `any` makes it impossible to assess and counteract their influence.
   - `any` has the same effect as going through the entire codebase to apply `@ts-ignore` to every single instance of the target variable or type.
-  <!-- TODO: Add example -->
   - Much like type assertions, code with `any` usage becomes brittle against changes, since the compiler is unable to update its feedback even if the suppressed error has been altered, or entirely new type errors have been added.
   <!-- TODO: Add example -->
 
@@ -727,7 +728,21 @@ All of this makes `any` a prominent cause of dangerous **silent failures**, wher
 - Every type is assignable to `unknown`, but `unknown` is not assignable to any type but itself.
 - When typing the _assignee_, `any` and `unknown` are completely interchangeable since every type is assignable to both.
 
-<!-- TODO: Add example -->
+**Example <a id="example-2e5889f6-110a-4c62-b659-20cfcc7c8916"></a> ([🔗 permalink](#example-2e5889f6-110a-4c62-b659-20cfcc7c8916)):**
+
+🚫 `any`
+
+```typescript
+type ExampleFunction = () => any
+const exampleArray: any[] = ['a', 1, true]
+```
+
+✅ `unknown`
+
+```typescript
+type ExampleFunction = () => unknown
+const exampleArray: unknown[] = ['a', 1, true]
+```
 
 #### If `any` is being used as the _assigned_ type, try `never` first, and then widening to an appropriate subtype of the _assignee_ type
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -237,6 +237,25 @@ Unsafe as type assertions may be, they are still categorically preferable to usi
 - With type assertions, we still get working intellisense, autocomplete, and other IDE and compiler features using the asserted type.
 - Type assertions also provide an indication of what the expected type is as intended by the author.
 - For type assertions to an incompatible shape, use `as unknown as` as a last resort rather than `any` or `as any`.
+- Often, the compiler will tell us exactly what the target type for an assertion needs to be, enabling us to avoid `as any`.
+
+```typescript
+// Error: Argument of type '"getNftInformation"' is not assignable to parameter of type 'keyof NftController'.ts(2345)
+// 'getNftInformation' is a private method of class 'NftController'
+sinon.stub(nftController, 'getNftInformation')
+```
+
+🚫 `as any`
+
+```typescript
+sinon.stub(nftController, 'getNftInformation' as any)
+```
+
+✅ Compiler specifies that the target type should be `keyof NftController`
+
+```typescript
+sinon.stub(nftController, 'getNftInformation' as keyof typeof nftController)
+```
 
 ##### For TypeScript syntax other than type assertion
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -768,6 +768,8 @@ mockGetNetworkConfigurationByNetworkClientId.mockImplementation(
 // Target signature provides too few arguments. Expected 2 or more, but got 1.ts(2345)
 ```
 
+> **Note:** This is an issue with `@types/jest` v27. Jest v29 no longer uses `any` as the default type for its generic parameters.
+
 #### `any` may be acceptable to use within generic constraints
 
 **Example <a id="example-706045b1-1f01-4e24-ae02-d9a3a8e81615"></a> ([🔗 permalink](#example-706045b1-1f01-4e24-ae02-d9a3a8e81615)):**

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -113,12 +113,20 @@ const BUILT_IN_NETWORKS = {
 
 ### Type Narrowing
 
-An explicit type annotation or assertion should only be used if...
+An explicit type annotation is acceptable to use for overriding an inferred type if...
 
-1) It can further narrow an inferred type, thus adding type information that the compiler cannot supply.
-2) It is the most accurate _and_ specific type assignable, in which case any code drift that changes the type of the assignee will trigger a useful type error.
+1) It can further narrow an inferred type, thus supplying type information that the compiler cannot infer or access.
+2) It is determined to be the most accurate _and_ specific type assignable.
 
-##### Type guards and null checks can be used to improve type inference
+#### Acceptable usages of `:` annotations
+
+##### To prevent or fix type assertions
+
+Type annotations are more responsive to code drift than assertions. If the assignee's type becomes incompatible with the assigned type annotation, the compiler will raise a type error, whereas in most cases a type assertion will still suppress the error.
+
+When the compiler is in doubt, an annotation will nudge it towards relying on type inference, while an assertion will force it to accept the user-supplied type.
+
+<!-- TODO: Add example -->
 
 ```typescript
 function isSomeInterface(x: unknown): x is SomeInterface {

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -45,7 +45,7 @@ const BUILT_IN_NETWORKS = {
 } as const; // Type { readonly mainnet: '0x1'; readonly goerli: '0x5'; }
 ```
 
-#### Example: To annotate or not to annotate
+##### Annotations can cause inaccurate typing and incorrectly resolved errors
 
 ```typescript
 type TransactionMeta = TransactionBase &

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -164,7 +164,42 @@ function f(x: SomeInterface | SomeOtherInterface) {
 
 #### Avoid `as`
 
-Type assertions make the code brittle against changes. While TypeScript will throw type errors against some unsafe or structurally unsound type assertions, it will generally accept the user-supplied type without type-checking. This can cause silent failures where errors are suppressed, even though the type's relationship to the rest of the code, or the type itself, has been altered so that the type assertion is no longer valid.
+Type assertions make the code brittle against changes.
+
+While TypeScript will throw type errors against some unsafe, structurally unsound, or redundant type assertions, it will generally accept the user-supplied type without type-checking.
+
+This can cause silent failures where errors are suppressed, even though the type's relationship to the rest of the code, or the type itself, may have been altered so that the type assertion is no longer valid.
+
+##### Redundant or unnecessary `as` assertions are not flagged for removal
+
+```ts
+import { getKnownPropertyNames } from '@metamask/utils';
+
+enum Direction {
+  Up = 'up',
+  Down = 'down',
+  Left = 'left',
+  Right = 'right',
+}
+const directions = Object.values(Direction);
+
+// Element implicitly has an 'any' type because index expression is not of type 'number'.(7015)
+for (const key of Object.keys(directions)) {
+  const direction = directions[key];
+}
+// Fix 1: use `as` assertion
+for (const key of Object.keys(directions)) {
+  const direction = directions[key as keyof typeof directions];
+}
+// Fix 2: use `getKnownPropertyNames`
+for (const key of getKnownPropertyNames(directions)) {
+  const direction = directions[key];
+}
+// Redundant `as` assertion does not trigger any warning
+for (const key of getKnownPropertyNames(directions)) {
+  const direction = directions[key as keyof typeof directions];
+}
+```
 
 #### Acceptable usages of `as`
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -45,6 +45,53 @@ const BUILT_IN_NETWORKS = {
 } as const; // Type { readonly mainnet: '0x1'; readonly goerli: '0x5'; }
 ```
 
+#### Example: To annotate or not to annotate
+
+```ts
+type TransactionMeta = TransactionBase &
+  (
+    | {
+        status: Exclude<TransactionStatus, TransactionStatus.failed>;
+      }
+    | {
+        status: TransactionStatus.failed;
+        error: TransactionError;
+      }
+  );
+
+const updatedTransactionMeta = {
+  ...transactionMeta,
+  status: TransactionStatus.rejected,
+};
+
+this.messagingSystem.publish(
+  `${controllerName}:transactionFinished`,
+  updatedTransactionMeta, // Expected type: 'TransactionMeta'
+);
+// Property 'error' is missing in type 'typeof updatedTransactionMeta' but required in type '{ status: TransactionStatus.failed; error: TransactionError; }'.ts(2345)
+```
+
+🚫 Add type annotation
+
+```ts
+// Type 'TransactionMeta'
+const updatedTransactionMeta: TransactionMeta = {
+  ...transactionMeta,
+  status: TransactionStatus.rejected,
+}; // resolves error
+```
+
+✅ Add `as const` and leave to inference
+
+```ts
+// Type narrower than 'TransactionMeta': { status: TransactionStatus.rejected; ... }
+// (doesn't include 'error' property)
+const updatedTransactionMeta = {
+  ...transactionMeta,
+  status: TransactionStatus.rejected as const,
+}; // resolves error
+```
+
 ### Type Narrowing
 
 There is a clear exception to the above: if an explicit type annotation or assertion can narrow an inferred type further, thereby improving its accuracy, it should be applied.

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -2,13 +2,13 @@
 
 ## Introduction
 
-This is a collection of TypeScript best practices and preferred conventions for contributors to the _MetaMask_ project.
+This is a collection of TypeScript best practices and preferred conventions for contributors to the MetaMask project.
 
 This document is not intended as a stand-in for linters or formatters. Emphasis is put on discussing underlying concepts and rationale, rather than listing rules and restrictions.
 
-Type safety is the highest priority in these guidelines, even if that sometimes means recommending unconventional or opinionated practices.
+Type safety and maintainability are the highest priorities in these guidelines, even if that sometimes leads to unconventional or opinionated recommendations.
 
-Note that this document assumes that the reader has a high level of familiarity with TypeScript, and may omit explanations.
+This document assumes that the reader has a high level of familiarity with TypeScript, and may omit explanations.
 
 ## Types
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -104,7 +104,10 @@ const BUILT_IN_NETWORKS = {
 
 ### Type Narrowing
 
-An explicit type annotation or assertion should only be used if it can further narrow an inferred type.
+An explicit type annotation or assertion should only be used if...
+
+1) It can further narrow an inferred type, thus adding type information that the compiler cannot supply.
+2) It is the most accurate _and_ specific type assignable, in which case any code drift that changes the type of the assignee will trigger a useful type error.
 
 ##### Type guards and null checks can be used to improve type inference
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -139,23 +139,31 @@ Introduced in [TypeScript 4.9](https://devblogs.microsoft.com/typescript/announc
 
 (continued from [previous example](#example-e9b0d703-032d-428b-a232-f5aa56a94470))
 
-🚫 Use a type annotation for type validation
+> **Error:** Object literal may only specify known properties, and 'nonTransactionMetaProperty' does not exist in type 'TransactionMeta'.ts(1360)
+
+🚫 Use a type annotation for type validation.
+
+`updatedTransactionMeta` is widened to `TransactionMeta`.
 
 ```typescript
 const updatedTransactionMeta: TransactionMeta = {
   ...transactionMeta,
   status: TransactionStatus.rejected,
+  nonTransactionMetaProperty: null,
 };
 
 updatedTransactionMeta.error; // Property 'error' does not exist on type '{ status: TransactionStatus.approved | TransactionStatus.cancelled | TransactionStatus.confirmed | TransactionStatus.dropped | TransactionStatus.rejected | TransactionStatus.signed | TransactionStatus.submitted | TransactionStatus.unapproved; ... }'.(2339)
 ```
 
-✅ Use the `satisfies` operator for type validation
+✅ Use the `satisfies` operator for type validation.
+
+`updatedTransactionMeta` is narrowed to its correct type signature (`status` property is not a union).
 
 ```typescript
 const updatedTransactionMeta = {
   ...transactionMeta,
   status: TransactionStatus.rejected as const,
+  nonTransactionMetaProperty: null,
 } satisfies TransactionMeta;
 
 updatedTransactionMeta.error; // Property 'error' does not exist on type '{ status: TransactionStatus.rejected; ... }'.(2339)

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -25,7 +25,7 @@ The intended _scope_ of this document does **not** include:
 TypeScript provides a range of syntax for communicating type information with the compiler.
 
 - The compiler performs **type inference** on all types and values in the code.
-- The user can assign **type annotations** (`:`) to override inferred types or add type constraints.
+- The user can assign **type annotations** (`:`, `satisfies`) to override inferred types or add type constraints.
 - The user can add **type assertions** (`as`, `!`) to force the compiler to accept user-supplied types even if they contradicts the inferred types.
 - Finally, there are **escape hatches** that let type checking be disabled (`any`, `@ts-expect-error`) for a certain scope of code.
 
@@ -43,6 +43,7 @@ However, for most types, inference should be preferred over annotations and asse
 
 - Explicit type annotations (`:`) and type assertions (`as`, `!`) prevent inference-based narrowing of the user-supplied types.
   - The compiler errs on the side of trusting user input, which prevents it from utilizing additional type information that it is able to infer.
+  - The `satisfies` operator is an exception to this rule.
 - Type inferences are responsive to changes in code without requiring user input, while annotations and assertions rely on hard-coding, making them brittle against code drift.
 - The `as const` operator can be used to narrow an inferred abstract type into a specific literal type, or do the same for the elements of an array or object.
 
@@ -133,14 +134,16 @@ const updatedTransactionMeta = {
 
 ### Type Annotations
 
-An explicit type annotation is acceptable for overriding an inferred type if...
+An explicit type annotation is acceptable for overriding an inferred type if:
 
-1. It can further narrow an inferred type, thus supplying type information that the compiler cannot infer or access.
-2. It is being used to enforce a type constraint rather than assign a type definition.
+1. It can further narrow an inferred type, supplying type information that the compiler cannot infer or access otherwise.
+2. It is being used to enforce a type constraint, not assign a type definition. For this use case, `satisfies` is preferred over `:`.
 
-##### Use the `satisfies` operator to enforce a type constraint or to validate the assigned type
+Compared to type assertions, type annotations are more responsive to code drift. If the assignee's type becomes incompatible with the assigned type annotation, the compiler will raise a type error, whereas in most cases a type assertion will still suppress the error.
 
-Introduced in [TypeScript 4.9](https://devblogs.microsoft.com/typescript/announcing-typescript-4-9/), the `satisfies` operator can be used to enforce a type constraint and further narrow the assigned type through inference.
+##### Prefer the `satisfies` operator over the `:` operator for enforcing type constraints
+
+Introduced in [TypeScript 4.9](https://devblogs.microsoft.com/typescript/announcing-typescript-4-9/), the `satisfies` operator can be used to enforce a type constraint, while also allowing the compiler to fully narrow the assigned type through inference.
 
 ###### Example (21ed5949-8d34-4754-b806-412de1696f46)
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -144,7 +144,7 @@ updatedTransactionMeta.error; // Type 'undefined'
 
 #### Acceptable usages of `:` annotations
 
-##### To prevent or fix type assertions
+##### Use type annotations if it will prevent or remove type assertions
 
 Type annotations are more responsive to code drift than assertions. If the assignee's type becomes incompatible with the assigned type annotation, the compiler will raise a type error, whereas in most cases a type assertion will still suppress the error.
 
@@ -210,7 +210,7 @@ for (const key of Object.keys(directions) as keyof directions[]) {
 }
 ```
 
-##### Type guards can be used to improve type inference
+##### Type guards can be used to improve type inference and avoid type assertion
 
 ```typescript
 function isSomeInterface(x: unknown): x is SomeInterface {
@@ -286,7 +286,7 @@ nftMetadataResults.filter(
 
 #### Acceptable usages of `as`
 
-##### To prevent or fix `any` usage
+##### `as` is acceptable to use for preventing or fixing `any` usage
 
 Unsafe as type assertions may be, they are still categorically preferable to using `any`.
 
@@ -314,7 +314,7 @@ sinon.stub(nftController, 'getNftInformation' as any);
 sinon.stub(nftController, 'getNftInformation' as keyof typeof nftController);
 ```
 
-##### For TypeScript syntax other than type assertion
+##### `as` is acceptable to use for TypeScript syntax other than type assertion
 
 - Writing type guards often reqiures using the `as` keyword.
 
@@ -332,7 +332,7 @@ type MappedTypeWithNewProperties<Type> = {
 };
 ```
 
-##### To type data objects whose shape and contents are determined at runtime, externally, or through deserialization
+##### `as` is acceptable to use for typing data objects whose shape and contents are determined at runtime, externally, or through deserialization
 
 Preferably, this typing should be accompanied by runtime schema validation performed with type guards and unit tests.
 
@@ -341,7 +341,7 @@ Preferably, this typing should be accompanied by runtime schema validation perfo
 
 <!-- TODO: Add example -->
 
-##### In tests, for mocking or to exclude irrelevant but required properties from an input object
+##### `as` may be acceptable to use in tests, for mocking or to exclude irrelevant but required properties from an input object
 
 <!-- TODO: Add examples -->
 
@@ -380,7 +380,7 @@ const { a, b, c } = returnsAny();
 
 All of this makes `any` a prominent cause of dangerous **silent failures**, where the code fails at runtime but the compiler does not provide any prior warning, defeating the purpose of using a statically-typed language.
 
-##### Try `unknown` and `never` instead
+##### When `any` , try `unknown` and `never` instead
 
 ###### `unknown`
 
@@ -441,7 +441,7 @@ mockGetNetworkConfigurationByNetworkClientId.mockImplementation(
 
 #### Acceptable usages of `any`
 
-##### Assigning new properties to a generic type at runtime
+##### `any` may be necessary when assigning new properties to or deleting properties from a generic type at runtime
 
 In most type errors involving property access or runtime property assignment, `any` usage can be avoided by substituting with `as unknown as`.
 
@@ -502,7 +502,7 @@ Object.assign(state, {
 };
 ```
 
-##### Within generic constraints
+##### `any` may be acceptable to use within generic constraints
 
 ✅
 
@@ -516,13 +516,13 @@ class BaseController<
 - In general, using `any` in this context is not harmful in the same way that it is in other contexts, as the `any` types only are not directly assigned to any specific variable, and only function as constraints.
 - That said, more specific constraints provide better type safety and intellisense, and should be preferred wherever possible.
 
-##### Catching errors
+##### `any` may be acceptable to use to type the error property in a catch block
 
 - `catch` only accepts `any` and `unknown` as the error type.
 - Recommended: Use `unknown` with type guards like `isJsonRpcError`.
 - Avoid typing an error object with `any` if it is passed on to be used elsewhere instead of just being thrown, as the `any` type will infect the downstream code.
 
-##### In tests, for mocking or to intentionally break features
+##### `any` may be acceptable to use in tests, to intentionally break features
 
 <!-- TODO: Add examples. Should be clear why type assertions couldn't be used instead -->
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -718,7 +718,7 @@ function f2(arg2: `0x${string}`) {
 }
 ```
 
-#### Don't allow generic type parameters to resolve to a default type of `any`
+#### Always supply a type argument for generic type parameters that have a default type of `any`
 
 Some generic types use `any` as a generic parameter default. If not consciously avoided, this can silently introduce an `any` type into the code, causing unexpected behavior and suppressing useful errors.
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -2,21 +2,13 @@
 
 ## Introduction
 
-### Purpose
+This is a collection of TypeScript best practices and preferred conventions for contributors to the _MetaMask_ project.
 
-The _purpose_ of this document is to:
+This document is not intended as a stand-in for linters or formatters. Emphasis is put on discussing underlying concepts and rationale, rather than listing rules and restrictions.
 
-- Present best practices and preferred conventions for contributing type-safe, maintainable TypeScript code.
-- Explain underlying concepts for issues that are not effectively resolved or prevented with blind compliance.
-- Serve as a **reference** during code review to encourage preferred approaches, minimize redundant discussion, and educate contributors about established practices.
+Type safety is the highest priority in these guidelines, even if that sometimes means recommending unconventional or opinionated practices.
 
-### Scope
-
-The intended _scope_ of this document does **not** include:
-
-- Becoming a comprehensive resource that covers all major aspects of syntax and style.
-- Redundantly listing or explaining conventions that are enforceable with linters or rulesets.
-- Endorsing practices for TypeScript code in external repos.
+Note that this document assumes that the reader has a high level of familiarity with TypeScript, and may omit explanations.
 
 ## Types
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -394,6 +394,10 @@ If that is not the case, however, mocking only the properties needed in the test
 
 TypeScript provides several directive comments that can be used to suppress TypeScript compiler errors. Using these to ignore typing issues is dangerous and reduces the overall effectiveness of TypeScript.
 
+Of these, we will discuss the use cases and pitfalls of `@ts-expect-error` and `any`.
+
+`@ts-ignore`, `@ts-nocheck`, `@ts-check` are disabled by ESLint rules.
+
 #### Acceptable usages of `@ts-expect-error`
 
 ##### Use `@ts-expect-error` to force runtime execution of a branch for validation or testing

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -533,19 +533,10 @@ TypeScript provides several escape hatches that disable compiler type checks alt
 
   - `@ts-expect-error` usage should generally be reserved to situations where an error is the intended or expected result of an operation, not to silence errors when the correct typing solution is difficult to find.
   - Allowed by the `@typescript-eslint/ban-ts-comment` rule, although a description comment is required.
-- `as any`
-
-  - Applies only to a single instance of a single variable without propagating to other instances.
-  - Banned by the `@typescript-eslint/no-explicit-any` rule.
-
-- `@ts-ignore`
-
-  - Applies to a line or block of code, which may contain multiple variables and errors.
-  - Does not propagate to instances of the target variable or type that are outside of its scope.
-  - Banned by the `@typescript-eslint/ban-ts-comment` rule.
 
 - `any`
   - Applies to all instances of the target variable or type throughout the entire codebase, and in downstream code as well.
+    - `as any` only applies to a single instance of a single variable without propagating to other instances.
   - Has the same effect as applying `@ts-ignore` to every single instance of the target variable or type.
   - Banned by the `@typescript-eslint/no-explicit-any` rule.
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -494,7 +494,14 @@ The key thing to remember about `any` is that it does not resolve errors, but on
 
 All of this makes `any` a prominent cause of dangerous **silent failures** (false negatives), where the code fails at runtime but the compiler does not provide any prior warning, which defeats the purpose of using a statically-typed language.
 
-##### If `any` is being used as the _assignee_ type, use `unknown` instead
+#### Prefer type assertions over `any`
+
+Type assertions are unsafe, but they are still always preferred over introducing `any` into the code.
+
+- With type assertions, we still get working intellisense, autocomplete, and other IDE and compiler features using the asserted type.
+- Type assertions also provide an indication of what the author intends or expects the type to be.
+- Even an assertion to a wrong type still allows the compiler to show us warnings and errors as the code changes.
+
 
 `any` usage is often motivated by a need to find a placeholder type that could be anything. `unknown` is the most likely type-safe substitute for `any` in these cases.
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -269,7 +269,7 @@ mockGetNetworkConfigurationByNetworkClientId.mockImplementation(
 - When typing the _assignee_, `any` and `unknown` are completely interchangeable since every type is assignable to both.
 - `any` usage is often motivated by a need to find a placeholder type that could be anything. `unknown` is the most likely type-safe substitute for `any` in these cases.
 
-##### `never`
+###### `never`
 
 - `never` is the universal subtype i.e. the narrowest possible type.
 - `never` is assignable to every type, but the only type that is assignable to `never` is `never`.
@@ -278,8 +278,7 @@ mockGetNetworkConfigurationByNetworkClientId.mockImplementation(
   - The type of the _assigned_ must be a subtype of the _assignee_.
   - `never` is worth trying, as it is the universal subtype and assignable to all types.
 
-  <!-- TODO: Add examples -->
-
+<!-- TODO: Add examples -->
 
 #### Acceptable usages of `any`
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -396,7 +396,8 @@ All of this makes `any` a prominent cause of dangerous **silent failures**, wher
 - When typing the _assigned_:
   - `unknown` is unable to replace `any`, as `unknown` is only assignable to `unknown`.
   - The type of the _assigned_ must be a subtype of the _assignee_.
-  - `never` is worth trying, as it is the universal subtype and assignable to all types.
+  - `never` is worth trying as a starting point, as it is the universal subtype and assignable to all types.
+  - If the assigned type simultaneously needs to be the assignee for another type, `never` will not work, as no type is assignable to `never`.
 
 <!-- TODO: Add examples -->
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -15,20 +15,52 @@ The general order of preference for using these features coincides with the orde
 
 ### Type Inference
 
-TypeScript is very good at inferring types. Explicit type annotations and assertions are the exception rather than the rule in a well-managed TypeScript codebase even with strong type safety guarantees.
+TypeScript is very good at inferring types. Explicit type annotations and assertions are the exception rather than the norm in a well-managed TypeScript codebase.
 
 Some fundamental type information must always be supplied by the user, such as function and class signatures, interfaces for interacting with external entities or data types, and types that express the domain model of the codebase.
 
-However, for the remaining majority of types and values, type inference should be preferred over type annotations and assertions.
+However, for the remaining majority of types and values, inference should be preferred over annotations and assertions.
 
 ##### Prefer type inference over annotations and assertions
 
 - Explicit type annotations (`:`) and type assertions (`as`, `!`) prevent further inference-based narrowing of the user-supplied types.
-  - The compiler errs on the side of trusting user input, which prevents it from providing additional type information that it is able to infer.
+  - The compiler errs on the side of trusting user input, which prevents it from utilizing additional type information that it is able to infer.
 - Type inferences are responsive to changes in code without requiring user input, while annotations and assertions rely on hard-coding, making them brittle against code drift.
-- The `as const` operator can be used to narrow an inferred abstract type into a specific literal type.
+- The `as const` operator can be used to narrow an inferred abstract type into a specific literal type. It can also be used on arrays and objects to achieve the same effect on their properties.
 
-##### Type annotations prevent inference-based narrowing of user-supplied types
+##### Avoid unintentionally widening an inferred type with a type annotation
+
+Enforcing a wider type defeats the purpose of adding an explicit type declaration, as it _loses_ type information instead of adding it. Double-check that the declared type is narrower than the inferred type.
+
+🚫 Type declarations
+
+```typescript
+const name: string = 'METAMASK'; // Type 'string'
+
+const chainId: string = this.messagingSystem(
+  'NetworkController:getProviderConfig',
+).chainId; // Type 'string'
+
+const BUILT_IN_NETWORKS = new Map<string, `0x${string}`>([
+  ['mainnet', '0x1'],
+  ['sepolia', '0xaa36a7'],
+]); // Type 'Map<string, `0x${string}`>'
+```
+
+✅ Type inferences
+
+```typescript
+const name = 'METAMASK'; // Type 'METAMASK'
+
+const chainId = this.messagingSystem(
+  'NetworkController:getProviderConfig',
+).chainId; // Type '`0x${string}`'
+
+const BUILT_IN_NETWORKS = {
+  mainnet: '0x1',
+  sepolia: '0xaa36a7',
+} as const; // Type { readonly mainnet: '0x1'; readonly sepolia: '0xaa36a7'; }
+```
 
 ```typescript
 type TransactionMeta = TransactionBase &
@@ -73,40 +105,6 @@ const updatedTransactionMeta = {
   ...transactionMeta,
   status: TransactionStatus.rejected as const,
 }; // resolves error
-```
-
-##### Avoid unintentionally widening an inferred type with an explicit type declaration
-
-Enforcing a wider type defeats the purpose of adding an explicit type declaration, as it _loses_ type information instead of adding it. Double-check that the declared type is narrower than the inferred type.
-
-🚫 Type declarations
-
-```typescript
-const name: string = 'METAMASK'; // Type 'string'
-
-const chainId: string = this.messagingSystem(
-  'NetworkController:getProviderConfig',
-).chainId; // Type 'string'
-
-const BUILT_IN_NETWORKS = new Map<string, `0x${string}`>([
-  ['mainnet', '0x1'],
-  ['sepolia', '0xaa36a7'],
-]); // Type 'Map<string, `0x${string}`>'
-```
-
-✅ Type inferences
-
-```typescript
-const name = 'METAMASK'; // Type 'METAMASK'
-
-const chainId = this.messagingSystem(
-  'NetworkController:getProviderConfig',
-).chainId; // Type '`0x${string}`'
-
-const BUILT_IN_NETWORKS = {
-  mainnet: '0x1',
-  sepolia: '0xaa36a7',
-} as const; // Type { readonly mainnet: '0x1'; readonly sepolia: '0xaa36a7'; }
 ```
 
 ### Type Annotations

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -128,7 +128,7 @@ const updatedTransactionMeta: TransactionMeta = {
   status: TransactionStatus.rejected,
 };
 
-updatedTransactionMeta.error; // Type 'TransactionError'
+updatedTransactionMeta.error; // Property 'error' does not exist on type '{ status: TransactionStatus.approved | TransactionStatus.cancelled | TransactionStatus.confirmed | TransactionStatus.dropped | TransactionStatus.rejected | TransactionStatus.signed | TransactionStatus.submitted | TransactionStatus.unapproved; ... }'.(2339)
 ```
 
 ✅ Use the `satisfies` operator for type validation
@@ -139,7 +139,7 @@ const updatedTransactionMeta = {
   status: TransactionStatus.rejected as const,
 } satisfies TransactionMeta;
 
-updatedTransactionMeta.error; // Type 'undefined'
+updatedTransactionMeta.error; // Property 'error' does not exist on type '{ status: TransactionStatus.rejected; ... }'.(2339)
 ```
 
 #### Acceptable usages of `:` annotations

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -11,7 +11,7 @@ TypeScript provides a range of syntax with which to communicate type information
 - The user can perform **type assertions** (`as`, `!`) to force the compiler to adhere to the user-supplied type even if it contradicts the compiler's inferences.
 - There are even **compiler directives** for disabling type checking (`any`, `@ts-expect-error`) for a limited scope of code.
 
-The general order of preference for using these language features coincides with the order in which they were just presented.
+fThe general order of preference for using these language features coincides with the order in which they were just presented.
 
 ### Type Inference
 
@@ -128,66 +128,6 @@ When the compiler is in doubt, an annotation will nudge it towards relying on ty
 
 <!-- TODO: Add example -->
 
-```typescript
-function isSomeInterface(x: unknown): x is SomeInterface {
-  return (
-    'name' in x &&
-    typeof x.name === 'string' &&
-    'length' in x &&
-    typeof x.length === 'number'
-  );
-}
-
-function f(x: SomeInterface | SomeOtherInterface) {
-  if (isSomeInterface(x)) {
-    // Type of x: 'SomeInterface | SomeOtherInterface'
-    console.log(x.name); // Type of x: 'SomeInterface'. Type of x.name: 'string'.
-  }
-}`
-```
-
-```typescript
-const nftMetadataResults = await Promise.allSettled(...);
-
-nftMetadataResults
-  .filter((promise) => promise.status === 'fulfilled')
-  .forEach((elm) =>
-    this.updateNft(
-      elm.value.nft, // Property 'value' does not exist on type 'PromiseRejectedResult'.ts(2339)
-      ...
-    ),
-  );
-```
-
-🚫 Type assertion
-
-```typescript
-nftMetadataResults.filter(
-    (promise) => promise.status === 'fulfilled',
-  ) as { status: 'fulfilled'; value: NftUpdate }[])
-  .forEach((elm) =>
-    this.updateNft(
-      elm.value.nft,
-      ...
-    ),
-  );
-```
-
-✅ Use a type guard as the predicate for the filter operation, enabling TypeScript to narrow the filtered results to `PromiseFulfilledResult` at the type level
-
-```typescript
-nftMetadataResults.filter(
-    (result): result is PromiseFulfilledResult<NftUpdate> =>
-      result.status === 'fulfilled',
-  )
-  .forEach((elm) =>
-    this.updateNft(
-      elm.value.nft,
-      ...
-    ),
-  );
-```
-
 ##### When instantiating an empty container type, provide a type annotation
 
 This is one case where type inference is unable to reach a useful conclusion without user-provided information. Since the compiler cannot arbitrarily restrict the range of types that could be inserted into the container, it has to assume the widest type, which is often `any`. It's up to the user to narrow that into the intended type by adding an explicit annotation.
@@ -230,7 +170,7 @@ This can cause silent failures or false negatives where errors are suppressed. T
 
 Type assertions can also cause false positives, because they assertions are independent expressions, untied to the type errors they were intended to fix. Thus, even if code drift fixes or removes a particular type error, the type assertions that were put in place to fix that error will provide no indication that they are no longer necessary and now should be removed.
 
-```ts
+```typescript
 enum Direction {
   Up = 'up',
   Down = 'down',
@@ -244,6 +184,80 @@ const directions = Object.values(Direction);
 for (const key of Object.keys(directions) as keyof directions[]) {
   const direction = directions[key as keyof typeof directions];
 }
+```
+
+##### Type guards can be used to improve type inference
+
+```typescript
+function isSomeInterface(x: unknown): x is SomeInterface {
+  return (
+    'name' in x &&
+    typeof x.name === 'string' &&
+    'length' in x &&
+    typeof x.length === 'number'
+  );
+}
+```
+
+🚫 Type assertion
+
+```typescript
+function f(x: SomeInterface | SomeOtherInterface) {
+  console.log((x as SomeInterface).name);
+}
+```
+
+✅ Narrowing with type guard
+
+```typescript
+function f(x: SomeInterface | SomeOtherInterface) {
+  if (isSomeInterface(x)) {
+    // Type of x: 'SomeInterface | SomeOtherInterface'
+    console.log(x.name); // Type of x: 'SomeInterface'. Type of x.name: 'string'.
+  }
+}
+```
+
+```typescript
+const nftMetadataResults = await Promise.allSettled(...);
+
+nftMetadataResults
+  .filter((promise) => promise.status === 'fulfilled')
+  .forEach((elm) =>
+    this.updateNft(
+      elm.value.nft, // Property 'value' does not exist on type 'PromiseRejectedResult'.ts(2339)
+      ...
+    ),
+  );
+```
+
+🚫 Type assertion
+
+```typescript
+(nftMetadataResults.filter(
+    (promise) => promise.status === 'fulfilled',
+  ) as { status: 'fulfilled'; value: NftUpdate }[])
+  .forEach((elm) =>
+    this.updateNft(
+      elm.value.nft,
+      ...
+    ),
+  );
+```
+
+✅ Use a type guard as the predicate for the filter operation, enabling TypeScript to narrow the filtered results to `PromiseFulfilledResult` at the type level
+
+```typescript
+nftMetadataResults.filter(
+    (result): result is PromiseFulfilledResult<NftUpdate> =>
+      result.status === 'fulfilled',
+  )
+  .forEach((elm) =>
+    this.updateNft(
+      elm.value.nft,
+      ...
+    ),
+  );
 ```
 
 #### Acceptable usages of `as`

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -29,7 +29,7 @@ Some fundamental type information must always be supplied by the user, such as f
 
 However, for most types, inference should be preferred over annotations and assertions.
 
-##### Prefer type inference over annotations and assertions
+#### Prefer type inference over annotations and assertions
 
 - Explicit type annotations (`:`) and type assertions (`as`, `!`) prevent inference-based narrowing of the user-supplied types.
   - The compiler errs on the side of trusting user input, which prevents it from utilizing additional type information that it is able to infer.
@@ -37,11 +37,11 @@ However, for most types, inference should be preferred over annotations and asse
 - Type inferences are responsive to changes in code without requiring user input, while annotations and assertions rely on hard-coding, making them brittle against code drift.
 - The `as const` operator can be used to narrow an inferred abstract type into a specific literal type, or do the same for the elements of an array or object.
 
-##### Avoid unintentionally widening an inferred type with a type annotation
+#### Avoid unintentionally widening an inferred type with a type annotation
 
 Enforcing a wider type defeats the purpose of adding an explicit type declaration, as it _loses_ type information instead of adding it. Double-check that the declared type is narrower than the inferred type.
 
-**Example <a id="example-aba42b65-1cb9-4df0-881e-c2e0e79db0bd"></a> ([🔗 permalink](#example-aba42b65-1cb9-4df0-881e-c2e0e79db0bd))**:
+##### **Example <a id="example-aba42b65-1cb9-4df0-881e-c2e0e79db0bd"></a> ([🔗 permalink](#example-aba42b65-1cb9-4df0-881e-c2e0e79db0bd)):**
 
 🚫 Type declarations
 
@@ -73,7 +73,7 @@ const BUILT_IN_NETWORKS = {
 } as const; // Type { readonly mainnet: '0x1'; readonly sepolia: '0xaa36a7'; }
 ```
 
-**Example <a id="example-e9b0d703-032d-428b-a232-f5aa56a94470"></a> ([🔗 permalink](#example-e9b0d703-032d-428b-a232-f5aa56a94470))**:
+##### **Example <a id="example-e9b0d703-032d-428b-a232-f5aa56a94470"></a> ([🔗 permalink](#example-e9b0d703-032d-428b-a232-f5aa56a94470)):**
 
 ```typescript
 type TransactionMeta = TransactionBase &
@@ -131,11 +131,11 @@ An explicit type annotation is acceptable for overriding an inferred type if:
 
 Compared to type assertions, type annotations are more responsive to code drift. If the assignee's type becomes incompatible with the assigned type annotation, the compiler will raise a type error, whereas in most cases a type assertion will still suppress the error.
 
-##### Prefer the `satisfies` operator over the `:` operator for enforcing type constraints
+#### Prefer `satisfies` annotation over `:` annotation for enforcing type constraints
 
 Introduced in [TypeScript 4.9](https://devblogs.microsoft.com/typescript/announcing-typescript-4-9/), the `satisfies` operator can be used to enforce a type constraint, while also allowing the compiler to fully narrow the assigned type through inference.
 
-**Example <a id="example-21ed5949-8d34-4754-b806-412de1696f46"></a> ([🔗 permalink](#example-21ed5949-8d34-4754-b806-412de1696f46))**:
+##### **Example <a id="example-21ed5949-8d34-4754-b806-412de1696f46"></a> ([🔗 permalink](#example-21ed5949-8d34-4754-b806-412de1696f46)):**
 
 🚫 Use a type annotation for type validation
 
@@ -159,7 +159,7 @@ const updatedTransactionMeta = {
 updatedTransactionMeta.error; // Property 'error' does not exist on type '{ status: TransactionStatus.rejected; ... }'.(2339)
 ```
 
-##### Provide a type annotation When instantiating an empty composite data-type value
+#### Provide a `:` annotation when instantiating an empty composite data-type value
 
 This is a special case where type inference cannot be expected to reach a useful conclusion without user-provided information.
 
@@ -167,7 +167,7 @@ The compiler doesn't have any values to use for inferring a type, and it cannot 
 
 It's up to the user to appropriately narrow down this type by adding an explicit annotation that provides information about the user's intentions.
 
-**Example <a id="example-b5a1175c-919f-4822-b92b-53a3d9dcd2e7"></a> ([🔗 permalink](#example-b5a1175c-919f-4822-b92b-53a3d9dcd2e7))**:
+##### **Example <a id="example-b5a1175c-919f-4822-b92b-53a3d9dcd2e7"></a> ([🔗 permalink](#example-b5a1175c-919f-4822-b92b-53a3d9dcd2e7)):**
 
 🚫
 
@@ -183,13 +183,13 @@ const tokens: string[] = []; // Type 'string[]'
 const tokensMap = new Map<string, Token>(); // Type 'Map<string, Token>'
 ```
 
-##### When typing an extensible data type, use a type annotation
+#### Prefer a `:` annotation over `satisfies` when typing an extensible data type
 
 The reason type inference and the `satisfies` operator are generally preferred over type annotations is that they provide us with the narrowest applicable type signature.
 
 When typing an extensible data type, however, this becomes a liability, because the narrowest type signature by definition doesn't include any newly assigned properties or elements. Therefore, when declaring or instantiating an object, array, or class, explicitly assign a type annotation, unless it is intended to be immutable.
 
-**Example <a id="example-a5fc6e57-2609-41c2-8315-558824bfffed"></a> ([🔗 permalink](#example-a5fc6e57-2609-41c2-8315-558824bfffed))**:
+##### **Example <a id="example-a5fc6e57-2609-41c2-8315-558824bfffed"></a> ([🔗 permalink](#example-a5fc6e57-2609-41c2-8315-558824bfffed)):**
 
 🚫 Type inference, `satisfies` operator
 
@@ -243,7 +243,7 @@ This can cause silent failures or false negatives where errors are suppressed. T
 
 Type assertions can also cause false positives, because assertions are independent expressions, untied to the type errors they were intended to fix. Even if code drift fixes or removes a particular type error, the type assertions that were put in place to fix that error will provide no indication that they are no longer necessary and now should be removed.
 
-**Example <a id="example-3675ab71-bcd6-4325-ac18-8ba4dd8ec03c"></a> ([🔗 permalink](#example-3675ab71-bcd6-4325-ac18-8ba4dd8ec03c))**:
+##### **Example <a id="example-3675ab71-bcd6-4325-ac18-8ba4dd8ec03c"></a> ([🔗 permalink](#example-3675ab71-bcd6-4325-ac18-8ba4dd8ec03c)):**
 
 ```typescript
 enum Direction {
@@ -261,9 +261,9 @@ for (const key of Object.keys(directions) as (keyof typeof directions)[]) {
 }
 ```
 
-##### Type guards can be used to improve type inference and avoid type assertion
+#### Avoid `as` assertions by using type guards to improve type inference
 
-**Example <a id="example-50c3fbc9-c2d7-4140-9f75-be5f0a56d541"></a> ([🔗 permalink](#example-50c3fbc9-c2d7-4140-9f75-be5f0a56d541))**:
+##### **Example <a id="example-50c3fbc9-c2d7-4140-9f75-be5f0a56d541"></a> ([🔗 permalink](#example-50c3fbc9-c2d7-4140-9f75-be5f0a56d541)):**
 
 ```typescript
 function isSomeInterface(x: unknown): x is SomeInterface {
@@ -297,7 +297,7 @@ function f(x: SomeInterface | SomeOtherInterface) {
 }
 ```
 
-**Example <a id="example-f7ff4b0d-e5e9-4568-b916-5153ddd2095b"></a> ([🔗 permalink](#example-f7ff4b0d-e5e9-4568-b916-5153ddd2095b))**:
+##### **Example <a id="example-f7ff4b0d-e5e9-4568-b916-5153ddd2095b"></a> ([🔗 permalink](#example-f7ff4b0d-e5e9-4568-b916-5153ddd2095b)):**
 
 ```typescript
 const nftMetadataResults = await Promise.allSettled(...);
@@ -343,18 +343,9 @@ nftMetadataResults.filter(
 
 > Note: The [`is` assertion is unnecessary](https://github.com/microsoft/TypeScript/pull/57465) as of TypeScript v5.5.
 
-#### Acceptable usages of `as`
+#### Determine the target type for an `as` assertion by examining compiler error messages
 
-Type assertions are unsafe, but they are still always preferred to introducing `any` into the code.
-
-- With type assertions, we still get working intellisense, autocomplete, and other IDE and compiler features using the asserted type.
-- Type assertions also provide an indication of what the author intends or expects the type to be.
-
-- Even an assertion to a wrong type still allows the compiler to show us warnings and errors as the code changes, and is therefore preferrable to the dangerous radio silence enforced by `any`.
-
-##### Prefer type assertions over `as any`
-
-Often, the compiler will tell us exactly what the target type for an assertion needs to be, enabling us to avoid `as any`.
+##### **Example <a id="example-2ee8f56a-e3be-417b-a2c0-260c1319b755"></a> ([🔗 permalink](#example-2ee8f56a-e3be-417b-a2c0-260c1319b755)):**
 
 **Example <a id="example-2ee8f56a-e3be-417b-a2c0-260c1319b755"></a> ([🔗 permalink](#example-2ee8f56a-e3be-417b-a2c0-260c1319b755))**:
 
@@ -376,19 +367,13 @@ sinon.stub(nftController, 'getNftInformation' as any);
 sinon.stub(nftController, 'getNftInformation' as keyof typeof nftController);
 ```
 
-##### `as` is acceptable to use for typing data objects whose structure and contents are determined at runtime
-
-This typing should be accompanied by schema validation or deserialization performed with type guards and unit tests.
-
-<!-- TODO: Add example -->
-
-#### `as` is always acceptable to use in the context of TypeScript syntax that does not involve type assertions
+#### `as` is always acceptable to use in TypeScript syntax that does not involve type assertions
 
 - `as const` assertions.
 
 - Key remapping in mapped types uses the `as` keyword.
 
-  **Example <a id="example-6ffd8c99-4768-42e1-8cb7-5710d14f8552"></a> ([🔗 permalink](#example-6ffd8c99-4768-42e1-8cb7-5710d14f8552))**:
+  ##### **Example <a id="example-6ffd8c99-4768-42e1-8cb7-5710d14f8552"></a> ([🔗 permalink](#example-6ffd8c99-4768-42e1-8cb7-5710d14f8552)):**
 
   ```typescript
   type MappedTypeWithNewProperties<Type> = {
@@ -428,9 +413,7 @@ In general, `@ts-expect-error` usage should be reserved to situations where an e
 
 Sometimes, there is a need to force a branch to execute at runtime for security or testing purposes, when that branch has correctly been inferred as being inaccessible by the TypeScript compiler.
 
-**Example <a id="example-76b145a7-89bf-4f19-914b-d1c02e2db185"></a> ([🔗 permalink](#example-76b145a7-89bf-4f19-914b-d1c02e2db185))**:
-
-✅
+##### **Example <a id="example-76b145a7-89bf-4f19-914b-d1c02e2db185"></a> ([🔗 permalink](#example-76b145a7-89bf-4f19-914b-d1c02e2db185)):**
 
 > **Error:** This comparison appears to be unintentional because the types '`0x${string}`' and '"**proto**"' have no overlap.ts(2367)
 
@@ -446,7 +429,7 @@ exampleFunction(chainId: `0x${string}`) {
 
 ##### `@ts-expect-error` may be acceptable to use in tests, to intentionally break features
 
-**Example <a id="example-e299e95d-1c41-4251-85b6-f8064b22f577"></a> ([🔗 permalink](#example-e299e95d-1c41-4251-85b6-f8064b22f577))**:
+##### **Example <a id="example-e299e95d-1c41-4251-85b6-f8064b22f577"></a> ([🔗 permalink](#example-e299e95d-1c41-4251-85b6-f8064b22f577)):**
 
 ✅
 
@@ -458,11 +441,11 @@ exampleFunction(chainId: `0x${string}`) {
 // @ts-expect-error We are intentionally passing bad input.
 ```
 
-##### If accompanied by a TODO comment, `@ts-expect-error` is acceptable to use for marking errors that have clear plans of being resolved
+#### If accompanied by a TODO comment, `@ts-expect-error` is acceptable to use for marking errors that have clear plans of being resolved
 
 <!-- TODO: Add example -->
 
-#### Avoid `any`
+#### Always avoid `any`
 
 `any` is the most dangerous form of explicit type declaration, and should be completely avoided.
 
@@ -476,7 +459,7 @@ The key thing to remember about `any` is that it does not resolve errors, but on
 - `any` suppresses all error messages about its assignee. This makes code with `any` usage brittle against changes, since the compiler is unable to update its feedback even when the code has changed enough to alter or remove the error, or even add new type errors.
 - `any` subsumes all other types it comes into contact with. Any type that is in a union, intersection, is a property of, or has any other relationship with an `any` type or value becomes an `any` type itself. This represents an unmitigated loss of type information.
 
-  **Example <a id="example-1fb5b0ad-61a9-4ad8-9d84-e29b78d88325"></a> ([🔗 permalink](#example-1fb5b0ad-61a9-4ad8-9d84-e29b78d88325))**:
+  ##### **Example <a id="example-1fb5b0ad-61a9-4ad8-9d84-e29b78d88325"></a> ([🔗 permalink](#example-1fb5b0ad-61a9-4ad8-9d84-e29b78d88325)):**
 
   ```typescript
   // Type of 'payload_0': 'any'
@@ -510,7 +493,7 @@ Unfortunately, when typing the _assigned_ type, `unknown` cannot substitute `any
 - `unknown` is only assignable to `unknown`.
 - The type of the _assigned_ must be a subtype of the _assignee_, but `unknown` can only be a subtype of `unknown`.
 
-  **Example <a id="example-56165606-17db-479d-a2f7-cc95250f2129"></a> ([🔗 permalink](#example-56165606-17db-479d-a2f7-cc95250f2129))**:
+##### **Example <a id="example-56165606-17db-479d-a2f7-cc95250f2129"></a> ([🔗 permalink](#example-56165606-17db-479d-a2f7-cc95250f2129)):**
 
   ```typescript
   function f1(arg1: string) { ... }
@@ -537,11 +520,11 @@ Unfortunately, when typing the _assigned_ type, `unknown` cannot substitute `any
   }
   ```
 
-##### Don't allow generic type parameters to resolve to a default type of `any`
+#### Don't allow generic type parameters to resolve to a default type of `any`
 
 Some generic types use `any` as a generic parameter default. If not consciously avoided, this can silently introduce an `any` type into the code, causing unexpected behavior and suppressing useful errors.
 
-**Example <a id="example-c64ed0da-01f1-4b61-a28a-ff8e8ab3c8b5"></a> ([🔗 permalink](#example-c64ed0da-01f1-4b61-a28a-ff8e8ab3c8b5))**:
+##### **Example <a id="example-c64ed0da-01f1-4b61-a28a-ff8e8ab3c8b5"></a> ([🔗 permalink](#example-c64ed0da-01f1-4b61-a28a-ff8e8ab3c8b5)):**
 
 🚫
 
@@ -567,11 +550,11 @@ mockGetNetworkConfigurationByNetworkClientId.mockImplementation(
 // Target signature provides too few arguments. Expected 2 or more, but got 1.ts(2345)
 ```
 
-##### Prefer `as unknown as` over `as any`
+#### Prefer `as unknown as` over `as any`
 
 In most type errors involving property access or runtime property assignment, `any` usage can be avoided by substituting with `as unknown as`.
 
-**Example <a id="example-03d4fc8b-73a3-478a-a986-df89c9b80775"></a> ([🔗 permalink](#example-03d4fc8b-73a3-478a-a986-df89c9b80775))**:
+##### **Example <a id="example-03d4fc8b-73a3-478a-a986-df89c9b80775"></a> ([🔗 permalink](#example-03d4fc8b-73a3-478a-a986-df89c9b80775)):**
 
 🚫
 
@@ -596,11 +579,9 @@ for (const key of getKnownPropertyNames(this.internalConfig)) {
 delete addressBook[chainId as unknown as `0x${string}`];
 ```
 
-#### Acceptable usages of `any`
+#### `any` may be acceptable to use within generic constraints
 
-##### `any` may be acceptable to use within generic constraints
-
-**Example <a id="example-706045b1-1f01-4e24-ae02-d9a3a8e81615"></a> ([🔗 permalink](#example-706045b1-1f01-4e24-ae02-d9a3a8e81615))**:
+##### **Example <a id="example-706045b1-1f01-4e24-ae02-d9a3a8e81615"></a> ([🔗 permalink](#example-706045b1-1f01-4e24-ae02-d9a3a8e81615)):**
 
 ✅
 
@@ -616,7 +597,7 @@ class BaseController<
 - More specific constraints provide better type safety and intellisense, and should be preferred wherever possible.
 - This only applies to generic _constraints_. It does not apply to passing in `any` as a generic _argument_.
 
-  **Example <a id="example-7b9781b4-0f33-4619-ba50-a90b2594e23f"></a> ([🔗 permalink](#example-7b9781b4-0f33-4619-ba50-a90b2594e23f))**:
+  ##### **Example <a id="example-7b9781b4-0f33-4619-ba50-a90b2594e23f"></a> ([🔗 permalink](#example-7b9781b4-0f33-4619-ba50-a90b2594e23f)):**
 
   🚫
 
@@ -627,11 +608,11 @@ class BaseController<
 
 ## Functions
 
-##### For functions and methods, provide explicit return types
+#### For functions and methods, provide explicit return types
 
 Although TypeScript is capable of inferring return types, adding them explicitly makes it much easier for the reader to see the API from the code alone and prevents unexpected changes to the API from emerging.
 
-**Example <a id="example-a88b18ef-b066-4aa7-8106-bc244298f9e6"></a> ([🔗 permalink](#example-a88b18ef-b066-4aa7-8106-bc244298f9e6))**:
+##### **Example <a id="example-a88b18ef-b066-4aa7-8106-bc244298f9e6"></a> ([🔗 permalink](#example-a88b18ef-b066-4aa7-8106-bc244298f9e6)):**
 
 🚫
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -1,16 +1,24 @@
 # TypeScript Guidelines
 
-The purpose of this article is to:
+## Introduction
 
-- Present best practices and preferred conventions for contributing type-safe and maintainable TypeScript code to MetaMask repos.
-- Explain concepts that can help resolve recurring issues that aren't preventable with compliance alone.
-- Serve as a reference during code review to encourage preferred approaches, minimize redundant discussion, and educate contributors about established practices.
+These guidelines apply to TypeScript code in MetaMask repos.
 
-This article does not aim to:
+### Purpose
 
-- Be a comprehensive resource covering all major aspects of syntax and style.
-- Redundantly list or explain conventions that are enforceable through linters or static rulesets.
-- Endorse its contents as being appropriate or useful for any TypeScript codebase outside of our own.
+The _purpose_ of this document is to:
+
+- Present best practices and preferred conventions for contributing type-safe, maintainable TypeScript code.
+- Explain underlying concepts for issues that are not effectively resolved or prevented with blind compliance.
+- Serve as a **reference** during code review to encourage preferred approaches, minimize redundant discussion, and educate contributors about established practices.
+
+### Scope
+
+The intended _scope_ of this document does **not** include:
+
+- Becoming a comprehensive resource that covers all major aspects of syntax and style.
+- Redundantly listing or explaining conventions that are enforceable with linters or rulesets.
+- Endorsing practices for TypeScript code in external repos.
 
 ## Types
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -23,28 +23,6 @@ There are several reasons for this:
 - Type inferences are responsive to changes in code without requiring user input, while annotations and assertions rely on hard-coding, making them brittle against code drift.
 - The `as const` operator can be used to narrow an inferred abstract type into a specific literal type.
 
-🚫 Type declarations
-
-```typescript
-const name: string = 'METAMASK'; // Type 'string'
-
-const BUILT_IN_NETWORKS = new Map<string, `0x${string}`>([
-  ['mainnet', '0x1'],
-  ['sepolia', '0xaa36a7'],
-]); // Type 'Map<string, `0x${string}`>'
-```
-
-✅ Type inferences
-
-```typescript
-const name = 'METAMASK'; // Type 'METAMASK'
-
-const BUILT_IN_NETWORKS = {
-  mainnet: '0x1',
-  sepolia: '0xaa36a7',
-} as const; // Type { readonly mainnet: '0x1'; readonly sepolia: '0xaa36a7'; }
-```
-
 ##### Type annotations prevent inference-based narrowing of user-supplied types
 
 ```typescript
@@ -92,49 +70,43 @@ const updatedTransactionMeta = {
 }; // resolves error
 ```
 
-### Type Narrowing
+##### Avoid unintentionally widening an inferred type with an explicit type declaration
 
-An explicit type annotation or assertion should not be avoided if they can further narrow an inferred type.
+Enforcing a wider type defeats the purpose of adding an explicit type declaration, as it _loses_ type information instead of adding it. Double-check that the declared type is narrower than the inferred type.
 
-##### Avoid unintentionally widening a type with a type annotation
-
-> **Warning**<br />
-> Enforcing an even wider type defeats the purpose of adding an explicit type annotation, as it _loses_ type information instead of adding it.<br />
-> Double-check that the declared type is narrower than the inferred type.
-
-🚫
+🚫 Type declarations
 
 ```typescript
+const name: string = 'METAMASK'; // Type 'string'
+
 const chainId: string = this.messagingSystem(
   'NetworkController:getProviderConfig',
 ).chainId; // Type 'string'
+
+const BUILT_IN_NETWORKS = new Map<string, `0x${string}`>([
+  ['mainnet', '0x1'],
+  ['sepolia', '0xaa36a7'],
+]); // Type 'Map<string, `0x${string}`>'
 ```
 
-✅
+✅ Type inferences
 
 ```typescript
+const name = 'METAMASK'; // Type 'METAMASK'
+
 const chainId = this.messagingSystem(
   'NetworkController:getProviderConfig',
 ).chainId; // Type '`0x${string}`'
+
+const BUILT_IN_NETWORKS = {
+  mainnet: '0x1',
+  sepolia: '0xaa36a7',
+} as const; // Type { readonly mainnet: '0x1'; readonly sepolia: '0xaa36a7'; }
 ```
 
-##### When instantiating an empty container type, provide a type annotation
+### Type Narrowing
 
-This is one case where type inference is unable to reach a useful conclusion without user-provided information. Since the compiler cannot arbitrarily restrict the range of types that could be inserted into the container, it has to assume the widest type, which is often `any`. It's up to the user to narrow that into the intended type by adding an explicit annotation.
-
-🚫
-
-```typescript
-const tokens = []; // Type 'any[]'
-const tokensMap = new Map(); // Type 'Map<any, any>'
-```
-
-✅
-
-```typescript
-const tokens: string[] = []; // Type 'string[]'
-const tokensMap = new Map<string, Token>(); // Type 'Map<string, Token>'
-```
+An explicit type annotation or assertion should be used if and only if they can further narrow an inferred type.
 
 ##### Type guards and null checks can be used to improve type inference
 
@@ -156,6 +128,24 @@ function f(x: SomeInterface | SomeOtherInterface) {
     console.log(x.name); // Type of x: 'SomeInterface'. Type of x.name: 'string'.
   }
 }`
+```
+
+##### When instantiating an empty container type, provide a type annotation
+
+This is one case where type inference is unable to reach a useful conclusion without user-provided information. Since the compiler cannot arbitrarily restrict the range of types that could be inserted into the container, it has to assume the widest type, which is often `any`. It's up to the user to narrow that into the intended type by adding an explicit annotation.
+
+🚫
+
+```typescript
+const tokens = []; // Type 'any[]'
+const tokensMap = new Map(); // Type 'Map<any, any>'
+```
+
+✅
+
+```typescript
+const tokens: string[] = []; // Type 'string[]'
+const tokensMap = new Map<string, Token>(); // Type 'Map<string, Token>'
 ```
 
 ### Type Assertions

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -123,7 +123,7 @@ const updatedTransactionMeta: TransactionMeta = {
 
 However, `TransactionMeta` is a [discriminated union](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions) of two separate types — "not failed" and "failed" — and the property that acts as the discriminator is `status`. Instead of using `TransactionMeta`, which specifies that a `error` property _could_ be present, it would be better to get TypeScript to infer the first of the two types ("not failed"), which guarantees that `error` is not present. We can do this by adding `as const` after `TransactionStatus.rejected`:
 
-``` typescript
+```typescript
 const updatedTransactionMeta = {
   ...transactionMeta,
   status: TransactionStatus.rejected as const,
@@ -435,12 +435,13 @@ TypeScript provides several escape hatches that disable compiler type checks alt
   - Is allowed by the ESLint rule `@typescript-eslint/ban-ts-comment`, but is required to be accompanied by an explanation comment.
   - **It alerts users if an error it was suppressing has been resolved by changes in the code**:
     > **Error:** Unused '@ts-expect-error' directive.
-  
 - `as any`
+
   - Applies to a single instance of a single variable.
   - Is banned by the ESLint rule `@typescript-eslint/no-explicit-any.
 
 - `@ts-ignore`
+
   - Applies to a line or block of code, which may contain multiple variables and errors.
   - Is banned by the ESLint rule `@typescript-eslint/ban-ts-comment`.
 
@@ -562,7 +563,7 @@ function f2(arg2: unknown) {
 ```typescript
 function f1(arg1: string) { ... }
 function f2(arg2: `0x${string}`) {
-  f1(arg2) 
+  f1(arg2)
 }
 ```
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -349,6 +349,8 @@ nftMetadataResults.filter(
   );
 ```
 
+> Note: The [`is` assertion is unnecessary](https://github.com/microsoft/TypeScript/pull/57465) as of TypeScript v5.5.
+
 #### Acceptable usages of `as`
 
 Although `as` is dangerous and discouraged from being used, the following is not intended as an exhaustive list of its valid use cases.

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -162,6 +162,12 @@ function f(x: SomeInterface | SomeOtherInterface) {
 
 `as` assertions are unsafe. They overwrite type-checked and inferred types with user-supplied types that suppress compiler errors.
 
+##### Document safe or necessary use of type assertions
+
+When a type assertion is absolutely necessary due to constraints or is even safe due to runtime checks, we should document the reason for doing so.
+
+<!-- TODO: Add example -->
+
 #### Avoid `as`
 
 Type assertions make the code brittle against changes.

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -99,7 +99,7 @@ this.messagingSystem.publish(
 // Property 'error' is missing in type 'typeof updatedTransactionMeta' but required in type '{ status: TransactionStatus.failed; error: TransactionError; }'.ts(2345)
 ```
 
-🚫
+🚫 Widen to `TransactionMeta`
 
 Adding a type annotation _does_ prevent the error above from being produced:
 
@@ -111,7 +111,7 @@ const updatedTransactionMeta: TransactionMeta = {
 };
 ```
 
-✅
+✅ Narrow to the correct type signature
 
 However, `TransactionMeta` is a [discriminated union](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions) of two separate types — "not failed" and "failed" — and the property that acts as the discriminator is `status`. Instead of using `TransactionMeta`, which specifies that a `error` property _could_ be present, it would be better to get TypeScript to infer the first of the two types ("not failed"), which guarantees that `error` is not present. We can do this by adding `as const` after `TransactionStatus.rejected`:
 
@@ -639,7 +639,9 @@ To prevent `any` instances from being introduced into the codebase, it is not en
 - `any` does not represent the widest type. In fact, it is not a type at all. `any` is a compiler directive for _disabling_ type checking for the value or type to which it's assigned.
 - `any` suppresses all error messages about its assignee.
   - The suppressed errors still affect the code, but `any` makes it impossible to assess and counteract their influence.
+  <!-- TODO: Add example -->
   - Much like type assertions, code with `any` usage becomes brittle against changes, since the compiler is unable to update its feedback even if the suppressed error has been altered, or entirely new type errors have been added.
+  <!-- TODO: Add example -->
 
 - `any` subsumes all other types it comes into contact with. Any type that is in a union, intersection, is a property of, or has any other relationship with an `any` type or value becomes an `any` type itself. This represents an unmitigated loss of type information.
 
@@ -659,6 +661,7 @@ To prevent `any` instances from being introduced into the codebase, it is not en
   ```
 
 - `any` infects all surrounding and downstream code with its directive to suppress errors. This is the most dangerous characteristic of `any`, as it causes the encroachment of unsafe code with no guarantees about type safety or runtime behavior.
+<!-- TODO: Add example -->
 
 All of this makes `any` a prominent cause of dangerous **silent failures** (false negatives), where the code fails at runtime but the compiler does not provide any prior warning, which defeats the purpose of using a statically-typed language.
 
@@ -679,9 +682,7 @@ Unfortunately, when typing the _assigned_ type, `unknown` cannot substitute `any
 - `unknown` is only assignable to `unknown`.
 - The type of the _assigned_ must be a subtype of the _assignee_, but `unknown` can only be a subtype of `unknown`.
 
-However, `never` is assignable to all types
-
-> **Note:** Once `unknown` has been ruled out as a substitute for `any`, trying `never` serves as a valuable test: It tells us that the search space for the correct substitute type is bounded to subtypes of the _assignee_ type.
+However, `never` is assignable to all types.
 
 **Example <a id="example-56165606-17db-479d-a2f7-cc95250f2129"></a> ([🔗 permalink](#example-56165606-17db-479d-a2f7-cc95250f2129)):**
 
@@ -710,6 +711,8 @@ function f2(arg2: unknown) {
 ```
 
 ✅ `never`
+
+> **Note:** Once `unknown` has been ruled out as a substitute for `any`, trying `never` serves as a useful test: It tells us that the search space for the correct substitute type is bounded to subtypes of the _assignee_ type.
 
 This works, but `arg2` can be widened further.
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -400,6 +400,12 @@ Of these, we will discuss the use cases and pitfalls of `@ts-expect-error` and `
 
 #### Acceptable usages of `@ts-expect-error`
 
+##### Prefer `@ts-expect-error` over `any`
+
+`@ts-expect-error` is a better alternative to `any` or `as`, because if the error it was suppressing has been resolved by changes in the code, it will alert users with the following message:
+
+> **Error:** Unused '@ts-expect-error' directive.
+
 ##### Use `@ts-expect-error` to force runtime execution of a branch for validation or testing
 
 Sometimes, there is a need to force a branch to execute at runtime for security or testing purposes, when that branch has correctly been inferred as being inaccessible by the TypeScript compiler.

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -166,17 +166,7 @@ const updatedTransactionMeta = {
 updatedTransactionMeta.error; // Property 'error' does not exist on type '{ status: TransactionStatus.rejected; ... }'.(2339)
 ```
 
-#### Acceptable usages of `:` annotations
-
-##### Use type annotations if it will prevent or remove type assertions
-
-Type annotations are more responsive to code drift than assertions. If the assignee's type becomes incompatible with the assigned type annotation, the compiler will raise a type error, whereas in most cases a type assertion will still suppress the error.
-
-When the compiler is in doubt, an annotation will nudge it towards relying on type inference, while an assertion will force it to accept the user-supplied type.
-
-<!-- TODO: Add example -->
-
-##### When instantiating an empty composite data-type value, provide a type annotation 
+##### When instantiating an empty composite data-type value, provide a type annotation
 
 This is one case where type inference is unable to reach a useful conclusion without user-provided information. Since the compiler cannot arbitrarily restrict the range of types that could be inserted into the container, it has to assume the widest type, which is often `any`. It's up to the user to narrow that into the intended type by adding an explicit annotation.
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -609,7 +609,17 @@ class BaseController<
 ```
 
 - In general, using `any` in this context is not harmful in the same way that it is in other contexts, as the `any` types only are not directly assigned to any specific variable, and only function as constraints.
-- That said, more specific constraints provide better type safety and intellisense, and should be preferred wherever possible.
+- More specific constraints provide better type safety and intellisense, and should be preferred wherever possible.
+- This only applies to generic _constraints_. It does not apply to passing in `any` as a generic _argument_.
+
+###### Example (7b9781b4-0f33-4619-ba50-a90b2594e23f)
+
+🚫
+
+```typescript
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const controllerMessenger = ControllerMessenger<any, any>;
+```
 
 ## Functions
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -169,7 +169,11 @@ updatedTransactionMeta.error; // Property 'error' does not exist on type '{ stat
 
 ##### When instantiating an empty composite data-type value, provide a type annotation
 
-This is one case where type inference is unable to reach a useful conclusion without user-provided information. Since the compiler cannot arbitrarily restrict the range of types that could be inserted into the container, it has to assume the widest type, which is often `any`. It's up to the user to narrow that into the intended type by adding an explicit annotation.
+This is a special case where type inference cannot be expected to reach a useful conclusion without user-provided information.
+
+The compiler doesn't have any values to use for inferring a type, and it cannot arbitrarily restrict the range of types that could be inserted into the collection. Given these restrictions, it has to assume the widest type, which is often `any`.
+
+It's up to the user to appropriately narrow down this type by adding an explicit annotation that provides information about the user's intentions.
 
 ###### Example (b5a1175c-919f-4822-b92b-53a3d9dcd2e7)
 
@@ -185,6 +189,42 @@ const tokensMap = new Map(); // Type 'Map<any, any>'
 ```typescript
 const tokens: string[] = []; // Type 'string[]'
 const tokensMap = new Map<string, Token>(); // Type 'Map<string, Token>'
+```
+
+##### When typing an extensible data type, use a type annotation
+
+The reason type inference and the `satisfies` operator are generally preferred over type annotations is that they provide us with the narrowest applicable type signature.
+
+When typing an extensible data type, however, this becomes a liability, because the narrowest type signature by definition doesn't include any newly assigned properties or elements. Therefore, when declaring or instantiating an object, array, or class, explicitly assign a type annotation, unless it is intended to be immutable.
+
+###### Example (a5fc6e57-2609-41c2-8315-558824bfffed)
+
+🚫 Type inference, `satisfies` operator
+
+```typescript
+// const SUPPORTED_CHAIN_IDS: ("0x1" | "0x38" | "0xa" | "0x2105" | "0x89" | "0xa86a" | "0xa4b1" | "0xaa36a7" | "0xe708")[]
+export const SUPPORTED_CHAIN_IDS = [ // inference
+  CHAIN_IDS.ARBITRUM,
+  CHAIN_IDS.AVALANCHE,
+  ...
+  CHAIN_IDS.SEPOLIA,
+];
+export const SUPPORTED_CHAIN_IDS = [ // `satisfies` operator
+  ...
+] satisfies `0x${string}`[];
+
+const { chainId } = networkController.state.providerConfig // Type of 'chainId': '`0x${string}`';
+SUPPORTED_CHAIN_IDS.includes(chainId) // Argument of type '`0x${string}`' is not assignable to parameter of type '"0x1" | "0x38" | "0xa" | "0x2105" | "0x89" | "0xa86a" | "0xa4b1" | "0xaa36a7" | "0xe708"'.ts(2345)
+```
+
+✅ Type annotation
+
+```typescript
+export const SUPPORTED_CHAIN_IDS: `0x${string}`[] = [ // type annotation
+  ...
+];
+const { chainId } = networkController.state.providerConfig // Type of 'chainId': '`0x${string}`';
+SUPPORTED_CHAIN_IDS.includes(chainId) // No error
 ```
 
 ### Type Assertions


### PR DESCRIPTION
## Motivation

In order to improve type safety and maintainability, we need to establish clear guidelines regarding how to apply types: specifically, when and when not to use explicit type declarations or keywords such as `as`, `any`.

## Explanation

- See markdown preview: [TypeScript Guidelines - "Types" section](https://github.com/MetaMask/contributor-docs/blob/240206-typescript-guidelines-any-as/docs/typescript.md)
- ~The merge conflicts with main will be resolved after the review process to avoid noisy diffs.~
- All examples are tagged with a permalink for easy reference and quotation.

### Table of Contents
- Types
  - Type Inference
  - Type Annotations (`:`, `satisfies`)
  - Type Assertions (`as`, `!`)
  - Escape Hatches (`any`, `@ts-expect-error`)
    
### Details
- Dangers and advantages.
- Tips for avoiding.
- Acceptable use cases.

## References
- Closes #47
- Closes #57 
- Contributes to #69