### PR TITLE
feat: Add examples of how to resolve a Socket.dev warning

### DIFF
--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -137,7 +137,9 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
     - Use the following etiquette when addressing Socket.dev warnings:
       - Investigate and address all warnings before merging a PR
       - Avoid using the `ignore-all` bot command, instead ignoring each warning one at a time
-      - If you've investigated a warning and found that it's not indicative of a malicious dependency, ignore it with a bot comment and explain your investigation with a short comment
+      - If you've investigated a warning and found that it's not indicative of a malicious dependency, ignore it with a bot comment and explain your investigation with a short comment. For example:
+        - For the "Network access" warning, verify that the package is supposed to have network access then leave a comment explaining your investigation.
+        - For the "New author" warning, leave a comment saying "Known maintainer" if you know the author. Otherwise, try to verify that they are the legitimate maintainers, and look for other suspicious changes in the versions they published (and review any LavaMoat policy changes, if your project uses LavaMoat)
       - Contact the security team if you're unsure how to investigate something, or if you'd like to disable a warning category
 
 #### LavaMoat (JavaScript projects only)


### PR DESCRIPTION
Two examples have been added that explain in further detail how to properly document that you've reviewed a Socket.dev warning.

This is an improvement suggested in this comment: https://github.com/MetaMask/contributor-docs/pull/58#discussion_r1394011196