### PR TITLE
feat: Improve `allow-scripts` instructions

### DIFF
--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -158,7 +158,11 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
   - On Yarn v3 projects, use [the `yarn-plugin-allow-scripts` plugin](https://github.com/LavaMoat/LavaMoat/tree/main/packages/yarn-plugin-allow-scripts) to run allowed scripts automatically during install
   - On other projects, use an npm script called `setup` that will call `install` and `allow-scripts` in sequence
 
-  Each time a dependency is added or updated, run `yarn allow-scripts auto` to detect new install scripts. They should be added to the configuration automatically, disabled by default. Review each one, only enabling those that are necessary. If you notice anything suspicious about the script or the package (e.g. if the maintainer has recently changed, or if the script appears to be obfuscated), consult with the security team before enabling it.
+  Each time a dependency is added or updated, run `yarn allow-scripts auto` to detect new install scripts. They should be added to the configuration automatically, disabled by default. Review each one, only enabling those that are necessary.
+
+  - Review the package contents and the source code for the script. Try to get a sense for what it does.
+  - Review the Socket.dev page for the package (you can find it at `socket.dev/npm/package/[]`). Review the package warnings.
+  - If you notice anything suspicious about the script or the package (e.g. if the maintainer has recently changed, if there is unexplained network or shell access, or if the script appears to be obfuscated), consult with the security team before enabling it.
 
 - LavaMoat runtime should be used for all Node.js build systems, and LavaMoat bundling tools should be used for all JavaScript client applications
   - The LavaMoat runtime helps protect against malicious code in dependencies by isolating dependencies and reducing their capabilities

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -155,7 +155,7 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 
   After setup and configuration, ensure that `allow-scripts` is run every time you install dependencies as part of your development workflow. There are two approaches to this:
 
-  - On Yarn v3 projects, use [the `yarn-plugin-allow-scripts` plugin](https://github.com/LavaMoat/LavaMoat/tree/main/packages/yarn-plugin-allow-scripts) to run allowed scripts automatically during install
+  - On Yarn Modern projects, use [the `yarn-plugin-allow-scripts` plugin](https://github.com/LavaMoat/LavaMoat/tree/main/packages/yarn-plugin-allow-scripts) to run allowed scripts automatically during install
   - On other projects, use an npm script called `setup` that will call `install` and `allow-scripts` in sequence
 
   Each time a dependency is added or updated, run `yarn allow-scripts auto` to detect new install scripts. They should be added to the configuration automatically, disabled by default. Review each one, only enabling those that are necessary.

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -161,7 +161,7 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
   Each time a dependency is added or updated, run `yarn allow-scripts auto` to detect new install scripts. They should be added to the configuration automatically, disabled by default. Review each one, only enabling those that are necessary.
 
   - Review the package contents and the source code for the script. Try to get a sense for what it does.
-  - Review the Socket.dev page for the package (you can find it at `socket.dev/npm/package/[]`). Review the package warnings.
+  - Review the Socket.dev page for the package (you can find it at `socket.dev/npm/package/[package name]`). Review the package warnings.
   - If you notice anything suspicious about the script or the package (e.g. if the maintainer has recently changed, if there is unexplained network or shell access, or if the script appears to be obfuscated), consult with the security team before enabling it.
 
 - LavaMoat runtime should be used for all Node.js build systems, and LavaMoat bundling tools should be used for all JavaScript client applications

--- a/docs/secure-coding-guidelines.md
+++ b/docs/secure-coding-guidelines.md
@@ -147,12 +147,19 @@ The guidelines in this policy were gathered primarily from the [OWASP Top 10](ht
 
 #### LavaMoat (JavaScript projects only)
 
-- LavaMoat `allow-scripts` should be enabled on all projects
-  - This project relies upon install scripts being disabled in your package manager. This can be verified by adding the dependency `@lavamoat/preinstall-always-fail`, which will cause installation to fail if scripts are enabled.
-  - `allow-scripts` acts as an allowlist for install scripts. Use the `allow-scripts` binary after installing dependencies to run install scripts on the allowlist.
-    - On Yarn v3 projects, use the `yarn-plugin-allow-scripts` plugin to run allowed scripts automatically during install
-    - On other projects, use an npm script called `setup` that will call `install` and `allow-scripts` in sequence
-  - If you're unsure whether an install script is needed, leave it disabled
+- LavaMoat `allow-scripts` should be enabled on all projects. This project uses an allowlist to run trusted install scripts, ensuring new or untrusted scripts are never run unexpectedly.
+
+  This project relies upon install scripts being disabled in your package manager. Install scripts should be run explicitly via `allow-scripts` instead, which uses the allowlist configured in `package.json`.
+
+  See [the `allow-scripts` README](https://github.com/LavaMoat/LavaMoat/tree/main/packages/allow-scripts) for setup and configuration instructions.
+
+  After setup and configuration, ensure that `allow-scripts` is run every time you install dependencies as part of your development workflow. There are two approaches to this:
+
+  - On Yarn v3 projects, use [the `yarn-plugin-allow-scripts` plugin](https://github.com/LavaMoat/LavaMoat/tree/main/packages/yarn-plugin-allow-scripts) to run allowed scripts automatically during install
+  - On other projects, use an npm script called `setup` that will call `install` and `allow-scripts` in sequence
+
+  Each time a dependency is added or updated, run `yarn allow-scripts auto` to detect new install scripts. They should be added to the configuration automatically, disabled by default. Review each one, only enabling those that are necessary. If you notice anything suspicious about the script or the package (e.g. if the maintainer has recently changed, or if the script appears to be obfuscated), consult with the security team before enabling it.
+
 - LavaMoat runtime should be used for all Node.js build systems, and LavaMoat bundling tools should be used for all JavaScript client applications
   - The LavaMoat runtime helps protect against malicious code in dependencies by isolating dependencies and reducing their capabilities
   - The LavaMoat bundling tools will bundle client applications with a LavaMoat runtime and policy


### PR DESCRIPTION
The `allow-scripts` instructions now defer to the `allow-scripts` README for setup instructions. Additionally, there is now a bit more guidance on how to decide whether to allow a script.