### PR TITLE
Update e2e-testing.md

### DIFF
--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -30,14 +30,7 @@ The test name should communicate the purpose and behaviour of the test. A clear 
 - send 1 TST to Bob
 ```
 
-⚠️ Test names remain approachable, recommend to avoid using the meaningless prefix 'should'
-
-```javascript
-- should add Bob to the address book
-- should send 1 TST to Bob
-```
-
-❌ Test name should be completely avoided: The use of a `should` prefix and the word `and` can decrease the readability of the test,making it harder to understand what the test is doing as well as diagnose and fix issues.
+❌ Test name should be completely avoided: Long test names that may over explain the test intention and the word `and` can decrease the readability of the test,making it harder to understand what the test is doing as well as diagnose and fix issues.
 
 ```javascript
 - should add Bob to the address book and send 1 TST to Bob

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -30,7 +30,7 @@ The test name should communicate the purpose and behaviour of the test. A clear 
 - send 1 TST to Bob
 ```
 
-❌ Test name should be completely avoided: Long test names that may over explain the test intention and the word `and` can decrease the readability of the test,making it harder to understand what the test is doing as well as diagnose and fix issues.
+❌ Test name should be completely avoided: Long test names that may over explain the test intention and the word `and` can decrease the readability of the test, making it harder to understand what the test is doing as well as diagnose and fix issues.
 
 ```javascript
 - should add Bob to the address book and send 1 TST to Bob


### PR DESCRIPTION
Discussed the use of the term 'should' at the start of test names.  Using 'should' at the start of test names is a long standing and accepted standard.  Our guidelines should be more aligned with the tools and frameworks guidelines and recommendations that we use.

Even repeated test names within a test file using 'should' at the start of test names should be considered valid.

The test framework we use implies all test names start with 'it' which makes 'should' coming after 'it' a more readable, expressive, and consistent practice.