### PR TITLE
fix: Exclude content from codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,5 @@
 # Each line is a file pattern followed by one or more owners.
 
 *                                   @MetaMask/wallet-framework-engineers
+!docs/**
+!examples/**


### PR DESCRIPTION
Only have codeownership on all the other parts but allow any dev to approve content changes