### PR TITLE
chore: Rename reference to extension main branch

### DIFF
--- a/docs/performance-tracing.md
+++ b/docs/performance-tracing.md
@@ -36,7 +36,7 @@ Or alternatively to track more technical code stages such as:
 
 ### Utilities
 
-The [trace utilities](https://github.com/MetaMask/metamask-extension/blob/develop/shared/lib/trace.ts) provide an abstraction of the respective Sentry package to create Sentry transactions with minimum syntax, but maximum simplicity to support features such as:
+The [trace utilities](https://github.com/MetaMask/metamask-extension/blob/main/shared/lib/trace.ts) provide an abstraction of the respective Sentry package to create Sentry transactions with minimum syntax, but maximum simplicity to support features such as:
 
 - Tags
 - Nested Traces


### PR DESCRIPTION
The main branch of the `metamask-extension` repository was recently renamed from `develop` to `main`. This updates a link to point to the correct branch.