### PR TITLE
Fix spelling errors

### DIFF
--- a/docs/migrations-guidelines.md
+++ b/docs/migrations-guidelines.md
@@ -26,7 +26,7 @@ Logs detailed errors and halts the migration if potential data corruption is ide
 
 - Log errors with `captureException` from Sentry, which is crucial for diagnosing issues post-migration,
 - Ensure that error messages are descriptive: include the migration number and a clear description of the issue,
-- If an exception is detected, indicating potential data corruption, halt the migration process and return the intial state,
+- If an exception is detected, indicating potential data corruption, halt the migration process and return the initial state,
 
 3. **Return State**:
 

--- a/docs/testing/e2e/extension-e2e-guidelines.md
+++ b/docs/testing/e2e/extension-e2e-guidelines.md
@@ -70,12 +70,12 @@ Here are some examples how to improve selectors following above guidelines:
 ```javascript
 // current element locator:
 .qr-code__wrapper
-// recommanded element locator: replace CSS locator with a data-testid
+// recommended element locator: replace CSS locator with a data-testid
 '[data-testid="account-details-qr-code"]'
 
 // current element locator:
 '//div[contains(@class, 'home-notification__text') and contains(text(), 'Backup your Secret Recovery Phrase to keep your wallet and funds secure')]'
-// recommanded element locator: replace XPATH with a query
+// recommended element locator: replace XPATH with a query
 '{ text: Backup your Secret Recovery Phrase to keep your wallet and funds secure, tag: div }'
 ```
 

--- a/examples/extension-e2e-page-object-model/login.flow.ts
+++ b/examples/extension-e2e-page-object-model/login.flow.ts
@@ -16,7 +16,7 @@ export const loginWithBalanceValidation = async (
   password: string = WALLET_PASSWORD,
   expectedBalance: string = DEFAULT_GANACHE_ETH_BALANCE_DEC,
 ) => {
-  console.log('Navigate to unlock page and try to login with pasword');
+  console.log('Navigate to unlock page and try to login with password');
   await driver.navigate();
   const loginPage = new LoginPage(driver);
   await loginPage.check_pageIsLoaded();


### PR DESCRIPTION
 - `"intial"` → `"initial"`  
 - `"recommanded"` → `"recommended"`
 - `"pasword"` → `"password"`  
