### PR TITLE
feat(4186): add doc for remote feature flag

### DIFF
--- a/docs/remote-feature-flags.md
+++ b/docs/remote-feature-flags.md
@@ -2,8 +2,18 @@
 
 ## Overview
 
-This document outlines the process for adding and managing remote feature flags in MetaMask (Extension and Mobile). Remote feature flags allow us to control feature availability and behavior in production without requiring a new release. They are created on the Launch Darkly platform and distributed by our internal API [ClientConfigAPI](https://github.com/consensys-vertical-apps/mmwp-client-config-api). Please read the [Remote feature flags ADR](https://github.com/MetaMask/decisions/pull/43) for more details.
+This document outlines the process for adding and managing remote feature flags in MetaMask (Extension and Mobile). Remote feature flags allow us to control feature availability and behavior in production without requiring a new release. They are created on the LaunchDarkly platform and distributed by our internal API [ClientConfigAPI](https://github.com/consensys-vertical-apps/mmwp-client-config-api). Please read the [Remote feature flags ADR](https://github.com/MetaMask/decisions/pull/43) for more details.
 
+### Choosing the Right Feature Flag Type
+
+Choose the appropriate feature flag type based on your needs:
+
+- **Boolean flag**: Use when you need a simple ON/OFF toggle for a feature
+
+- **Object flag with scope based on "threshold"**: Use for:
+  - controlling % of users who see a feature
+  - A/B testing different feature variants
+  
 ## Implementation Guide
 
 ### 1. Creating a New Feature Flag

--- a/docs/remote-feature-flags.md
+++ b/docs/remote-feature-flags.md
@@ -6,17 +6,88 @@ This document outlines the process for adding and managing remote feature flags 
 
 ### Choosing the Right Feature Flag Type
 
-Choose the appropriate feature flag type based on your needs:
+Choose the appropriate feature flag type based on your needs, and you can create a new feature flag with thresholds by adding a new feature flag in LaunchDarkly with the following JSON:
 
-- **Boolean flag**: Use when you need a simple ON/OFF toggle for a feature
+**1. Boolean flag**: Use when you need a simple ON/OFF toggle for a feature. In this example: `my-feature` is enabled for all users.
 
-- **Object flag with scope based on "threshold"**: Use for:
-  - controlling % of users who see a feature
-  - A/B testing different feature variants
-  
+```json
+{
+  "name": "my-feature",
+  "value": true
+}
+```
+
+**2. Object flag with scope based on "threshold"**: Use for:
+
+- controlling % of users who see a feature
+  In this example: the feature is enabled for 30% of users and disabled for 70% of users.
+
+```json
+[
+  {
+    "name": "feature is ON",
+    "scope": {
+      "type": "threshold",
+      "value": 0.3
+    },
+    "value": true
+  },
+  {
+    "name": "feature is OFF",
+    "scope": {
+      "type": "threshold",
+      "value": 1
+    },
+    "value": false
+  }
+]
+```
+
+- A/B testing different feature variants
+  In this configuration, the swap button will be blue for 25% of users, red for 25% of users, green for 25% of users, and yellow for 25% of users
+
+```json
+[[
+  {
+    "name": "blue",
+    "scope": {
+      "type": "threshold",
+      "value": 0.25
+    },
+    "value": "0000FF"
+  },
+  {
+    "name": "red",
+    "scope": {
+      "type": "threshold",
+      "value": 0.5
+    },
+    "value": "FF0000"
+  },
+  {
+    "name": "green",
+    "scope": {
+      "type": "threshold",
+      "value": 0.75
+    },
+    "value": "00FF00"
+  },
+  {
+    "name": "yellow",
+    "scope": {
+      "type": "threshold",
+      "value": 1
+    },
+    "value": "FFF500"
+  }
+]
+```
+
+The distribution is deterministic based on the user's `metametricsId`, ensuring consistent group assignment across sessions.
+
 ## Implementation Guide
 
-### 1. Creating a New Feature Flag
+### 1. Creating feature flag in LaunchDarkly.
 
 1. Name your flag with team prefix (e.g., `confirmations-blockaid`, `ramps-card`)
 2. Request LaunchDarkly access from TechOps. Here's a template email:
@@ -35,7 +106,7 @@ Thanks!
    - Mobile: "MetaMask Client Config API - Mobile"
 4. Create the flag following the [LaunchDarkly flag creation guide](https://docs.launchdarkly.com/home/flags/new)
 
-### 2. Using Remote Feature Flags in MetaMask
+### 2. Using Remote Feature Flags in MetaMask clients
 
 #### Extension
 
@@ -75,46 +146,7 @@ Your selector must include:
 > [!IMPORTANT]
 > Always use the specific feature flag selector when accessing values. Accessing feature flags directly from Redux state or the main selector bypasses fallback values and can cause crashes.
 
-### 3. Remote Feature Flags with thresholds
-
-#### Create a new feature flag with thresholds
-
-You can create a new feature flag with thresholds by adding a new feature flag in LaunchDarkly with the following JSON:
-
-```json
-[
-  {
-    "name": "groupA",
-    "scope": {
-      "type": "threshold",
-      "value": 0.3
-    },
-    "value": "valueA"
-  },
-  {
-    "name": "groupB",
-    "scope": {
-      "type": "threshold",
-      "value": 0.5
-    },
-    "value": "valueB"
-  },
-  {
-    "name": "groupC",
-    "scope": {
-      "type": "threshold",
-      "value": 1
-    },
-    "value": "valueC"
-  }
-]
-```
-
-#### Feature Flag Values with Scope Based on "metametricsId"
-
-When initializing the `RemoteFeatureFlag` controller, user would have to pass in `metetricsId` to the constructor. Based on the `metetricsId`, controller generates a deterministic random number between 0 and 1, and then compares the random number with the threshold value of each group. The group whose threshold value is greater than or equal to the random number will be selected.
-
-### 4. Testing Remote Feature Flags
+### 3. Testing Remote Feature Flags
 
 #### Extension
 

--- a/docs/remote-feature-flags.md
+++ b/docs/remote-feature-flags.md
@@ -1,0 +1,170 @@
+# Remote Feature Flags
+
+## Overview
+
+This document outlines the process for adding and managing remote feature flags in MetaMask (Extension and Mobile). Remote feature flags allow us to control feature availability and behavior in production without requiring a new release. They are created on the Launch Darkly platform and distributed by our internal API [ClientConfigAPI](https://github.com/consensys-vertical-apps/mmwp-client-config-api). Please read the [Remote feature flags ADR](https://github.com/MetaMask/decisions/pull/43) for more details.
+
+## Implementation Guide
+
+### 1. Creating a New Feature Flag
+
+1. Name your flag with team prefix (e.g., `confirmations-blockaid`, `ramps-card`)
+2. Request LaunchDarkly access from TechOps. Here's a template email:
+
+```
+Subject: Requesting access to LaunchDarkly for [team]
+
+Dear TechOps,
+Can I please get access to LaunchDarkly with the "Metamask Extension and Mobile" role? (role key: `metamask-config`)
+
+Thanks!
+```
+
+3. Select appropriate project in LaunchDarkly:
+   - Extension: "MetaMask Client Config API - Extension"
+   - Mobile: "MetaMask Client Config API - Mobile"
+4. Create the flag following the [LaunchDarkly flag creation guide](https://docs.launchdarkly.com/home/flags/new)
+
+### 2. Using Remote Feature Flags in MetaMask
+
+#### Extension
+
+To use a remote feature flag in the MetaMask extension, follow these steps:
+
+1. Add selector from `import { getRemoteFeatureFlags } from 'path/to/selectors';` in your component file.
+2. Use the selector to get the feature flag value.
+
+```typescript
+const { testFeatureFlag } = getRemoteFeatureFlags(state);
+```
+
+3. Use the feature flag value in your component.
+
+```typescript
+if (testFeatureFlag) {
+  // Use the feature flag value
+}
+```
+
+#### Mobile
+
+##### Create a selector for your feature flag
+
+- Location: `app/selectors/featureFlagsController`
+- Create a new folder with your feature flag name
+- Follow the structure from `app/selectors/featureFlagsController/minimumAppVersion`
+
+Your selector must include:
+
+- State selectors for each feature flag value
+- Fallback values for invalid remote flag values
+- TypeScript types
+- Unit tests
+- Any required business logic for value manipulation
+
+> **Important**: Always use the specific feature flag selector when accessing values. Accessing feature flags directly from Redux state or the main selector bypasses fallback values and can cause crashes.
+
+### 3. Remote Feature Flags with thresholds
+
+#### Create a new feature flag with thresholds
+
+You can create a new feature flag with thresholds by adding a new feature flag in LaunchDarkly with the following JSON:
+
+```json
+[
+  {
+    "name": "groupA",
+    "scope": {
+      "type": "threshold",
+      "value": 0.3
+    },
+    "value": "valueA"
+  },
+  {
+    "name": "groupB",
+    "scope": {
+      "type": "threshold",
+      "value": 0.5
+    },
+    "value": "valueB"
+  },
+  {
+    "name": "groupC",
+    "scope": {
+      "type": "threshold",
+      "value": 1
+    },
+    "value": "valueC"
+  }
+]
+```
+
+#### Feature Flag Values with Scope Based on "metametricsId"
+
+When initializing the `RemoteFeatureFlag` controller, user would have to pass in `metetricsId` to the constructor. Based on the `metetricsId`, controller generates a deterministic random number between 0 and 1, and then compares the random number with the threshold value of each group. The group whose threshold value is greater than or equal to the random number will be selected.
+
+### 4. Testing Remote Feature Flags
+
+#### Extension
+
+##### Local Feature Flag Override
+
+- Developers can override `remoteFeatureFlag` values by defining them in `.manifest-overrides.json` and enable `MANIFEST_OVERRIDES=.manifest-overrides.json` in the `.metamaskrc.dist` locally.
+- These overrides take precedence over values received from the controller
+- Accessible in all development environments:
+  - Local builds
+  - Webpack builds
+  - E2E tests
+
+##### Developer Validation
+
+##### A. Local Build
+
+1. Define overrides in `remoteFeatureFlags` in `manifest-overrides.json`:
+
+```json
+{
+  "_flags": {
+    "remoteFeatureFlags": {
+      "testFlagForThreshold": {
+        "name": "test-flag",
+        "value": "121212"
+      }
+    }
+  }
+}
+```
+
+2. Verify in Developer Options:
+   - Open extension
+   - Click on the account menu (top-right corner)
+   - Select "Settings" > "Developer Options"
+   - Look for "Remote Feature Flags" section to verify your overrides
+
+##### B. E2E Test
+
+Add the customized value in your test configuration:
+
+```typescript
+fixtures: new FixtureBuilder()
+  .withMetaMetricsController({
+    metaMetricsId: MOCK_META_METRICS_ID,
+    participateInMetaMetrics: true,
+  })
+  .build(),
+```
+
+#### Mobile
+
+##### Local Feature Flag Override
+
+1. Set environment variable in `.js.env` and run the app. This forces the fallback values to override any remote values.
+
+```
+OVERRIDE_REMOTE_FEATURE_FLAGS=TRUE
+```
+
+2. Test different feature flag scenarios:
+   - Modify the default values in your feature flag selector
+   - Run the application to verify behavior with different values
+   - Remember to test both override and non-override scenarios

--- a/docs/remote-feature-flags.md
+++ b/docs/remote-feature-flags.md
@@ -6,7 +6,7 @@ This document outlines the process for adding and managing remote feature flags 
 
 ### Choosing the Right Feature Flag Type
 
-Choose the appropriate feature flag type based on your needs, and you can create a new feature flag with thresholds by adding a new feature flag in LaunchDarkly with the following JSON:
+Choose the appropriate feature flag type based on your needs:
 
 **1. Boolean flag**: Use when you need a simple ON/OFF toggle for a feature. In this example: `my-feature` is enabled for all users.
 

--- a/docs/testing/e2e/mobile-e2e-mocking.md
+++ b/docs/testing/e2e/mobile-e2e-mocking.md
@@ -1,4 +1,3 @@
-
 # Mocking APIs in MetaMask Mobile for Enhanced E2E Testing
 
 ## Introduction
@@ -17,6 +16,7 @@ We use mocking to enhance our E2E testing, especially for scenarios where E2E al
 ## File Structure
 
 We keep E2E and mock tests separate with file naming conventions:
+
 ```
 root/
 ├── e2e/
@@ -32,6 +32,7 @@ root/
 │       │   ├── mock-responses/
 │       │   │   ├── gas-api-responses.json
 ```
+
 This structure promotes clear organisation and makes managing tests simpler.
 
 ## Mock Server Implementation
@@ -58,12 +59,8 @@ The `startMockServer` function in `e2e/api-mocking/mock-server.js` starts the mo
 import { mockEvents } from '../api-mocking/mock-config/mock-events';
 
 mockServer = await startMockServer({
-  GET: [
-    mockEvents.GET.suggestedGasApiErrorResponse,
-  ],
-  POST: [
-    mockEvents.POST.suggestedGasApiPostResponse,
-  ],
+  GET: [mockEvents.GET.suggestedGasApiErrorResponse],
+  POST: [mockEvents.POST.suggestedGasApiPostResponse],
 });
 ```
 
@@ -98,6 +95,7 @@ export const mockEvents = {
 Mock responses are stored in individual JSON files for each API or service within the `mock-responses` folder, making them easier to maintain and manage. Each API service has its own JSON response file, such as `gasApiResponse.json` for gas-related responses and `ethpriceResponse.json` for Ethereum price responses. This organisation enables clear separation of mock data and simplifies updates or additions.
 
 **Example:** `gasApiResponse.json`
+
 ```json
 {
   "suggestedGasApiResponses": {
@@ -117,7 +115,6 @@ The mock server logs response statuses and bodies to help track mocked requests,
 
 ## Using Mock Testing Effectively
 
-
 ### When to Use Mocks:
 
 - For testing isolated features without relying on live data
@@ -126,13 +123,12 @@ The mock server logs response statuses and bodies to help track mocked requests,
 
 ### When Not to Use Mocks:
 
--	Stable Live Environments: When APIs and services are reliable, testing live ensures production-like accuracy.
+- Stable Live Environments: When APIs and services are reliable, testing live ensures production-like accuracy.
 - Integration Testing: Live tests validate interactions with third-party services, capturing real-world behaviour.
 - Performance Testing: Only live environments provide accurate latency and throughput metrics.
 - Dynamic Data Scenarios: Features relying on user data or complex workflows may reveal issues that mocks miss.
 
 There should be a mix of tests that verify real-life services and some that use mocks, when applicable, to achieve comprehensive coverage.
-
 
 ### Utilizing Fixtures with testSpecificMock
 
@@ -145,7 +141,8 @@ test.use({
   testSpecificMock: {
     GET: [
       {
-        urlEndpoint: 'https://gas.api.cx.metamask.io/networks/1/suggestedGasFees',
+        urlEndpoint:
+          'https://gas.api.cx.metamask.io/networks/1/suggestedGasFees',
         response: { status: 200, message: 'Custom Success Response' },
       },
     ],


### PR DESCRIPTION
Fix: https://github.com/MetaMask/MetaMask-planning/issues/4186

Create a documentation to explain other teams how to use remote feature flags.

This also includes the documentation from mobile side by @joaoloureirop 🙏🏻 
https://www.notion.so/metamask-consensys/Remote-feature-flags-with-Launch-Darkly-197f86d67d6880be86ffecbd313f62cf