### PR TITLE
Fix typos in Documentation Files

### DIFF
--- a/docs/engineering-principles.md
+++ b/docs/engineering-principles.md
@@ -33,7 +33,7 @@ We believe in the right of our users to own their own identity and data. We must
 
 ### The Principle of Auditability
 
-As we are committed to providing a high level of security and privacy within our product, we must also maintain an auditable, publically accessible, and transparent codebase. We mustn't ask our users to trust our products implicitly, but instead, write code that explicitly illustrates our values. In order for our codebase to be easily auditable, our code must have the following qualities:
+As we are committed to providing a high level of security and privacy within our product, we must also maintain an auditable, publicly accessible, and transparent codebase. We mustn't ask our users to trust our products implicitly, but instead, write code that explicitly illustrates our values. In order for our codebase to be easily auditable, our code must have the following qualities:
 
 1. Readability - Our code should be easily read, and be free of obfuscation or subterfuge.
 2. Consistency - Our code should follow consistent standards to assist auditors in tracing code paths across multiple repositories or code from varying authors.

--- a/docs/redux.md
+++ b/docs/redux.md
@@ -204,7 +204,7 @@ function myReducer(state = initialState, action) {
 
 As detailed in the [Official Redux Style Guide](https://redux.js.org/style-guide/#avoid-putting-form-state-in-redux) below is a lists of recommended patterns, best practices, and suggested approaches for writing Redux applications.
 
-These patters are split into 3 categories of rules
+These patterns are split into 3 categories of rules
 
 - **Priority A: Essential** - These rules help prevent errors, so learn and abide by them at all costs.
 - **Priority B: Strongly Recommended** - These rules have been found to improve readability and/or developer experience in most projects.

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -616,7 +616,7 @@ exampleFunction('__proto__');
 ✅
 
 ```typescript
-// @ts-expect-error TODO: remove this annotation once the `Eip1193Provider` class is released, resolving thi provider misalignment issue.
+// @ts-expect-error TODO: remove this annotation once the `Eip1193Provider` class is released, resolving this provider misalignment issue.
 return new Web3Provider(provider);
 
 // TODO: Fix this by handling or eliminating the undefined case


### PR DESCRIPTION
- Fixed the typo "publically" to "publicly".
- "patters" to "patterns".
- "resolving thi provider" to "resolving this provider".