### PR TITLE
Improve TypeScript example for conditional Omit usage

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -928,10 +928,14 @@ interface CartItem {
   color?: string; // Optional color
 
 // Omit color if quantity is 1
-const singleItemPayload = Omit<CartItem, "color" extends string ? "color" : never>;
+type SingleItemPayload<T extends CartItem> = T extends { quantity: 1 }
+  ? Omit<T, 'color'>
+  : T
 
-// Omit color for all items if quantity is always 1
-const cartPayload: singleItemPayload[] = [];
+// Omit color for all items when quantity is 1
+const cartPayload: SingleItemPayload<CartItem & { quantity: 1 }>[] = [
+  { productId: 123, quantity: 1 },
+];
 ```
 
 ## Interfaces


### PR DESCRIPTION
### Description
This PR updates the TypeScript documentation with a clearer example of using `Omit` with conditional types. The new example makes it easier to understand how to conditionally remove properties based on the value of `quantity`.

### Changes
- Replaced the previous `singleItemPayload` example with a more precise generic type `SingleItemPayload<T>`.
- Improved the explanation and updated the example to show how `color` is omitted when `quantity === 1`.

### Before
```typescript
const singleItemPayload = Omit<CartItem, "color" extends string ? "color" : never>;
const cartPayload: singleItemPayload[] = [];
```

### After
```typescript
type SingleItemPayload<T extends CartItem> = T extends { quantity: 1 }
  ? Omit<T, 'color'>
  : T

const cartPayload: SingleItemPayload<CartItem & { quantity: 1 }>[] = [
  { productId: 123, quantity: 1 },
];
```
