### PR TITLE
chore: Update codeowners to remove `MetaMask/core-platform` from `docs` folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,6 @@
 # Each line is a file pattern followed by one or more owners.
 
 * @MetaMask/core-platform
+
+# Docs folder is not owned by any specific team.
+/docs


### PR DESCRIPTION
This changes `CODEOWNERS` so `MetaMask/core-platform` owns everything, except the `docs` folder.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only changes review ownership rules and does not affect runtime behavior or shipped code.
> 
> **Overview**
> Adjusts `.github/CODEOWNERS` to keep `@MetaMask/core-platform` as the default owner for `*`, but explicitly excludes `/docs` so it has no specific code owner.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a50ce472b77ca5a3faca0548906fbed4157c8a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->