### PR TITLE
TypeScript guidelines: Add `Derive types from authoritative sources` guideline

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -122,6 +122,45 @@ const updatedTransactionMeta = {
 };
 ```
 
+#### Derive types from authoritative sources instead of re-declaring them
+
+When a type already exists at an authoritative source — a controller's state type, a function's return, a package's exported type, a schema — reference and **derive** from it rather than hand-writing a fresh type that restates its shape. This is the type-level counterpart to preferring inference: indexed access (`State['field']`), `typeof`, `ReturnType` / `Parameters`, and utility types (`Pick` / `Omit` / `Partial`) let a derived type track its source automatically.
+
+- A hand-written type that restates an existing one **duplicates** the shape: every reader must reconcile the two, and every change has to touch both.
+- The restatement is a _guess_ at the source's shape, and the guess is almost always **wider** than the real type — it admits values the authoritative type would reject (see [Avoid unintentionally widening an inferred type with a type annotation](#avoid-unintentionally-widening-an-inferred-type-with-a-type-annotation)). Marking every field optional is the most common way this happens.
+- Because the copy is hard-coded rather than derived, it is **brittle against code drift** (see [Prefer type inference over annotations and assertions](#prefer-type-inference-over-annotations-and-assertions)): when the source evolves the copy silently goes stale, and the compiler cannot flag the divergence, so the failure surfaces at runtime rather than at build.
+
+Define a fresh type only when no authoritative source exists — a genuinely new shape at a boundary the code owns. Before defining, look for the source: the type is often already exported from the `@metamask/*` package the value comes from.
+
+🚫 Re-declare a slice of an existing controller state type
+
+```typescript
+// Restates part of NetworkController state: all-optional (wider than the real,
+// required field), keyed by `string` instead of `Hex`, and unlinked from the
+// source — so it drifts silently when the controller's shape changes.
+type NetworkControllerState = {
+  networkConfigurationsByChainId?: Record<
+    string,
+    {
+      defaultRpcEndpointIndex?: number;
+      rpcEndpoints?: { networkClientId?: string }[];
+    }
+  >;
+};
+```
+
+✅ Derive the slice from the authoritative exported type
+
+```typescript
+import type { NetworkState } from '@metamask/network-controller';
+
+// Tracks NetworkController's real shape (`Record<Hex, NetworkConfiguration>`)
+// and narrows to just the field in use.
+type NetworkConfigurations = NetworkState['networkConfigurationsByChainId'];
+```
+
+The derived form stays correct when `NetworkController` changes `networkConfigurationsByChainId`; the hand-written copy does not, and the compiler cannot tell you it has gone stale.
+
 ### Type Annotations
 
 An explicit type annotation may be used to override an inferred type if:

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -132,34 +132,41 @@ When a type already exists at an authoritative source — a controller's state t
 
 Define a fresh type only when no authoritative source exists — a genuinely new shape at a boundary the code owns. Before defining, look for the source: the type is often already exported from the `@metamask/*` package the value comes from.
 
-🚫 Re-declare a slice of an existing controller state type
+**Example <a id="example-5f6f1503-1ce6-432f-8d38-61d0f44a03ce"></a> ([🔗 permalink](#example-5f6f1503-1ce6-432f-8d38-61d0f44a03ce)):**
+
+🚫 A dependency typed too wide, which forces every consumer to re-cast the shape by hand:
 
 ```typescript
-// Restates part of NetworkController state: all-optional (wider than the real,
-// required field), keyed by `string` instead of `Hex`, and unlinked from the
-// source — so it drifts silently when the controller's shape changes.
-type NetworkControllerState = {
-  networkConfigurationsByChainId?: Record<
-    string,
-    {
-      defaultRpcEndpointIndex?: number;
-      rpcEndpoints?: { networkClientId?: string }[];
-    }
-  >;
+type Dependencies = {
+  // `Record<string, unknown>` is a placeholder, not a type: it discards the real
+  // state shape, so nothing downstream can be read without a cast.
+  getMetaMaskState: () => Record<string, unknown>;
 };
+
+// Reading a field requires re-declaring its shape at the use site …
+const { tokensChainsCache } = getMetaMaskState() as {
+  tokensChainsCache?: Record<string, { data?: Record<string, unknown> }>;
+};
+
+// … and passing the state to a typed selector requires an `as never` to force
+// the mismatch through:
+getTokensControllerAllTokens({ metamask: getMetaMaskState() } as never);
 ```
 
-✅ Derive the slice from the authoritative exported type
+✅ Type the dependency from the authoritative controller state; the field is then derivable and the selector type-checks, with no casts:
 
 ```typescript
-import type { NetworkState } from '@metamask/network-controller';
+import type { TokenListState } from '@metamask/assets-controllers';
 
-// Tracks NetworkController's real shape (`Record<Hex, NetworkConfiguration>`)
-// and narrows to just the field in use.
-type NetworkConfigurations = NetworkState['networkConfigurationsByChainId'];
+type Dependencies = {
+  // Composed from the controller-state types the module actually reads.
+  getMetaMaskState: () => TokenListState /* & …other controller state… */;
+};
+
+const { tokensChainsCache } = getMetaMaskState(); // typed; no cast
 ```
 
-The derived form stays correct when `NetworkController` changes `networkConfigurationsByChainId`; the hand-written copy does not, and the compiler cannot tell you it has gone stale.
+The `Record<string, unknown>` did not save work — it moved the work downstream into a cast at every use site, including an `as never` that silently defeats the selector's parameter type. Deriving the dependency from the authoritative state removes both.
 
 ### Type Annotations
 


### PR DESCRIPTION
Adds a `Derive types from authoritative sources instead of re-declaring them` subsection to the **Type Inference** section.

The section already covers preferring inference for values and avoiding accidental widening, but not the common case (especially with AI) of hand-writing a *type* that restates one an authoritative source already defines. 

Includes counterexamples.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to internal TypeScript guidelines; no runtime or build behavior.
> 
> **Overview**
> Adds a **Type Inference** subsection, **Derive types from authoritative sources instead of re-declaring them**, to `docs/typescript.md`. It tells contributors to use indexed access, `typeof`, `ReturnType`/`Parameters`, and `Pick`/`Omit`/`Partial` instead of hand-written types that duplicate controller state, package exports, or other canonical shapes.
> 
> The text covers duplication, overly wide or narrow restatements (including dropped `| undefined` and “dead” guards), drift when the source changes, and extra risk at JS/`any` boundaries where restated parameter types are never checked. Two 🚫/✅ examples show `Record<string, unknown>` and casts vs `TokenListState`, and a JS caller with `StorageShape | undefined` vs a narrowed parameter that invites removing a default.
> 
> A small formatting tweak adds a blank line before a bullet under **Avoid `any`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b87151f283defe37c4591f2d1e4292e145bf5514. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->